### PR TITLE
separate library from other top level declarations

### DIFF
--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -203,7 +203,7 @@
 		},
 		{
 			"comment": "Top level declaration",
-			"begin": "\\b(library|contract|script|predicate)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+			"begin": "\\b(library)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
 			"end": "[\\{\\(;]",
 			"beginCaptures": {
 				"1": {
@@ -211,6 +211,39 @@
 				},
 				"2": {
 					"name": "entity.name.type.sway"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#block_comment"
+				},
+				{
+					"include": "#line_comment"
+				},
+				{
+					"include": "#impl"
+				},
+				{
+					"include": "#type_params"
+				},
+				{
+					"include": "#core_types"
+				},
+				{
+					"include": "#pub"
+				},
+				{
+					"include": "#where"
+				}
+			]
+		},
+		{
+			"comment": "Top level declaration without name",
+			"begin": "\\b(contract|script|predicate)",
+			"end": "[;]",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.sway"
 				}
 			},
 			"patterns": [


### PR DESCRIPTION
since script, contract and predicate don't take a name after declaration I needed to separate them from library syntax pattern