### PR TITLE
Add `install-extension` script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ dist
 # Ignore Typescript files
 out
 .vscode-test
+sway-vscode-plugin.vsix

--- a/package.json
+++ b/package.json
@@ -3,11 +3,17 @@
     "displayName": "sway-vscode-plugin",
     "description": "Sway Language Extension",
     "version": "0.0.1",
+    "publisher": "FuelLabs",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/FuelLabs/sway-vscode-plugin.git"
+    },
     "scripts": {
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -b",
         "watch": "tsc -b -w",
-        "test": "sh ./scripts/e2e.sh"
+        "test": "sh ./scripts/e2e.sh",
+        "install-extension": "npx vsce package -o sway-vscode-plugin.vsix && code --install-extension sway-vscode-plugin.vsix"
     },
     "engines": {
         "vscode": "^1.55.0"


### PR DESCRIPTION
I've made the necessary changes to make `vsce` work and added an npm script that runs this command to build&package&install the extension:
`npx vsce package -o sway-vscode-plugin.vsix && code --install-extension sway-vscode-plugin.vsix`

With this testing the ext becomes:
```sh
git clone git@github.com:FuelLabs/sway-vscode-plugin.git
cd sway-vscode-plugin
npm i
npm run install-extension
```
