### PR TITLE
Improve syntax highlight

### DIFF
--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -396,7 +396,7 @@
 		"core_types": {
 			"comment": "Built-in/core type",
 			"name": "support.type.primitive.sway",
-			"match": "\\b(bool|char|u8|u16|u32|u64|u128|string|b256|b512|str|Self)\\b"
+			"match": "\\b(bool|char|u8|u16|u32|u64|string|b256|str|Self)\\b"
 		},
 		"type": {
 			"comment": "A type",


### PR DESCRIPTION
Small PR to improve syntax highlighting in VS Code based on the text's tokenisation. I didn't touch the Language Server yet

- fix string highlight
- add `abi` declaration
- add `b256` and `b512`