### PR TITLE
fix: prevent highlighting contract keyword as part of string

### DIFF
--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -242,36 +242,12 @@
 		},
 		{
 			"comment": "Top level declaration without name",
-			"begin": "\\b(contract|script|predicate)",
-			"end": "[;]",
-			"beginCaptures": {
+			"match": "(contract|script|predicate);",
+			"captures": {
 				"1": {
 					"name": "storage.type.sway"
 				}
-			},
-			"patterns": [
-				{
-					"include": "#block_comment"
-				},
-				{
-					"include": "#line_comment"
-				},
-				{
-					"include": "#impl"
-				},
-				{
-					"include": "#type_params"
-				},
-				{
-					"include": "#core_types"
-				},
-				{
-					"include": "#pub"
-				},
-				{
-					"include": "#where"
-				}
-			]
+			}
 		},
 		{
 			"comment": "Type declaration",


### PR DESCRIPTION
`contract` is highlighted incorrectly even when it's part of a variable name. It's fixed by this PR

Close #18 