### PR TITLE
upgrade vscode engine to match types/vscode dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:fix": "npx prettier --write 'client/src' 'snippets' 'syntaxes'"
   },
   "engines": {
-    "vscode": "^1.55.0"
+    "vscode": "^1.64.0"
   },
   "categories": [
     "Programming Languages",


### PR DESCRIPTION
I was getting an error when running `npm run install-extension` 

` @types/vscode ^1.64.0 greater than engines.vscode ^1.55.0. Consider upgrade engines.vscode or use an older @types/vscode version`

I found the same error reported [here](https://github.com/dependabot/dependabot-core/issues/2035) 

The vscode engine needs to be upgraded to match the types/vscode dep.