### PR TITLE
Enable trace server options for Sway 

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -18,7 +18,7 @@ let client: LanguageClient;
 export function activate(context: ExtensionContext) {
   client = new LanguageClient(
     "sway-lsp",
-    "Sway LSP",
+    "Sway Language Server",
     getServerOptions(context),
     getClientOptions()
   );

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,8 +17,8 @@ let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
   client = new LanguageClient(
-    "forc",
-    "Sway",
+    "sway-lsp",
+    "Sway LSP",
     getServerOptions(context),
     getClientOptions()
   );

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,4 +1,19 @@
 {
+  "type": "object",
+  "title": "Sway LSP",
+  "properties": {
+    "sway-lsp.trace.server": {
+      "scope": "window",
+      "type": "string",
+      "enum": [
+        "off",
+        "messages",
+        "verbose"
+      ],
+      "default": "verbose",
+      "description": "Traces the communication between VS Code and the language server."
+    }
+  },
   "comments": {
     // symbol used for single line comment. Remove this entry if your language does not support line comments
     "lineComment": "//",

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,19 +1,4 @@
 {
-  "type": "object",
-  "title": "Sway LSP",
-  "properties": {
-    "sway-lsp.trace.server": {
-      "scope": "window",
-      "type": "string",
-      "enum": [
-        "off",
-        "messages",
-        "verbose"
-      ],
-      "default": "verbose",
-      "description": "Traces the communication between VS Code and the language server."
-    }
-  },
   "comments": {
     // symbol used for single line comment. Remove this entry if your language does not support line comments
     "lineComment": "//",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,23 @@
     "onLanguage:sway"
   ],
   "contributes": {
+    "configuration": {
+			"type": "object",
+			"title": "Sway",
+			"properties": {
+				"sway-lsp.trace.server": {
+					"scope": "window",
+					"type": "string",
+          "description": "Traces the communication between VS Code and the Sway language server.",
+					"enum": [
+						"off",
+						"messages",
+						"verbose"
+					],
+					"default": "off"
+				}
+			}
+		},
     "languages": [
       {
         "id": "sway",

--- a/package.json
+++ b/package.json
@@ -33,22 +33,22 @@
   ],
   "contributes": {
     "configuration": {
-			"type": "object",
-			"title": "Sway",
-			"properties": {
-				"sway-lsp.trace.server": {
-					"scope": "window",
-					"type": "string",
+      "type": "object",
+      "title": "Sway",
+      "properties": {
+        "sway-lsp.trace.server": {
+          "scope": "window",
+          "type": "string",
           "description": "Traces the communication between VS Code and the Sway language server.",
-					"enum": [
-						"off",
-						"messages",
-						"verbose"
-					],
-					"default": "off"
-				}
-			}
-		},
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off"
+        }
+      }
+    },
     "languages": [
       {
         "id": "sway",


### PR DESCRIPTION
This now shows Sway under the extensions panel in vscode settings. 

Under the sway section, you can now set the level of verbosity that can print to the output tab when the server is running and a sway file is open. 