### PR TITLE
Add Show Parsed Tokens as Warnings toggle and enable client logging

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,0 +1,86 @@
+import * as vscode from 'vscode';
+import { log } from "./util";
+
+export class Config {
+    readonly extensionId = "fuellabs.sway-vscode-plugin";
+    readonly rootSection = "sway-lsp";
+    private readonly requiresReloadOpts = [
+        "debug",
+    ]
+        .map(opt => `${this.rootSection}.${opt}`);
+
+    readonly package: {
+        version: string;
+    } = vscode.extensions.getExtension(this.extensionId)!.packageJSON;
+
+    readonly globalStorageUri: vscode.Uri;
+
+    constructor(ctx: vscode.ExtensionContext) {
+        this.globalStorageUri = ctx.globalStorageUri;
+        vscode.workspace.onDidChangeConfiguration(this.onDidChangeConfiguration, this, ctx.subscriptions);
+        this.refreshLogging();
+    }
+
+    private refreshLogging() {
+        log.setEnabled(this.traceExtension);
+        log.info("Starting the Sway Language Client and Server");
+        log.info("Extension version:", this.package.version);
+
+        const cfg = Object.entries(this.cfg).filter(([_, val]) => !(val instanceof Function));
+        log.info("Using configuration", Object.fromEntries(cfg));
+    }
+
+    private async onDidChangeConfiguration(event: vscode.ConfigurationChangeEvent) {
+        this.refreshLogging();
+
+        const requiresReloadOpt = this.requiresReloadOpts.find(
+            opt => event.affectsConfiguration(opt)
+        );
+
+        if (!requiresReloadOpt) return;
+
+        const userResponse = await vscode.window.showInformationMessage(
+            `Changing "${requiresReloadOpt}" requires a reload`,
+            "Reload now"
+        );
+
+        if (userResponse === "Reload now") {
+            await vscode.commands.executeCommand("workbench.action.reloadWindow");
+        }
+    }
+
+    // We don't do runtime config validation here for simplicity. More on stackoverflow:
+    // https://stackoverflow.com/questions/60135780/what-is-the-best-way-to-type-check-the-configuration-for-vscode-extension
+
+    private get cfg(): vscode.WorkspaceConfiguration {
+        return vscode.workspace.getConfiguration(this.rootSection);
+    }
+
+    /**
+     * Beware that postfix `!` operator erases both `null` and `undefined`.
+     * This is why the following doesn't work as expected:
+     *
+     * ```ts
+     * const nullableNum = vscode
+     *  .workspace
+     *  .getConfiguration
+     *  .getConfiguration("sway-lsp")
+     *  .get<number | null>(path)!;
+     *
+     * // What happens is that type of `nullableNum` is `number` but not `null | number`:
+     * const fullFledgedNum: number = nullableNum;
+     * ```
+     * So this getter handles this quirk by not requiring the caller to use postfix `!`
+     */
+    private get<T>(path: string): T {
+        return this.cfg.get<T>(path)!;
+    }
+
+    get traceExtension() { return this.get<boolean>("trace.extension"); }
+
+    get debug() {
+        return {
+            showParsedTokensAsWarnings: this.get<boolean>("debug.showParsedTokensAsWarnings")
+        }
+    }
+}

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,86 +1,97 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 import { log } from "./util";
 
 export class Config {
-    readonly extensionId = "fuellabs.sway-vscode-plugin";
-    readonly rootSection = "sway-lsp";
-    private readonly requiresReloadOpts = [
-        "debug",
-    ]
-        .map(opt => `${this.rootSection}.${opt}`);
+  readonly extensionId = "fuellabs.sway-vscode-plugin";
+  readonly rootSection = "sway-lsp";
+  private readonly requiresReloadOpts = ["debug"].map(
+    (opt) => `${this.rootSection}.${opt}`
+  );
 
-    readonly package: {
-        version: string;
-    } = vscode.extensions.getExtension(this.extensionId)!.packageJSON;
+  readonly package: {
+    version: string;
+  } = vscode.extensions.getExtension(this.extensionId)!.packageJSON;
 
-    readonly globalStorageUri: vscode.Uri;
+  readonly globalStorageUri: vscode.Uri;
 
-    constructor(ctx: vscode.ExtensionContext) {
-        this.globalStorageUri = ctx.globalStorageUri;
-        vscode.workspace.onDidChangeConfiguration(this.onDidChangeConfiguration, this, ctx.subscriptions);
-        this.refreshLogging();
+  constructor(ctx: vscode.ExtensionContext) {
+    this.globalStorageUri = ctx.globalStorageUri;
+    vscode.workspace.onDidChangeConfiguration(
+      this.onDidChangeConfiguration,
+      this,
+      ctx.subscriptions
+    );
+    this.refreshLogging();
+  }
+
+  private refreshLogging() {
+    log.setEnabled(this.traceExtension);
+    log.info("Starting the Sway Language Client and Server");
+    log.info("Extension version:", this.package.version);
+
+    const cfg = Object.entries(this.cfg).filter(
+      ([_, val]) => !(val instanceof Function)
+    );
+    log.info("Using configuration", Object.fromEntries(cfg));
+  }
+
+  private async onDidChangeConfiguration(
+    event: vscode.ConfigurationChangeEvent
+  ) {
+    this.refreshLogging();
+
+    const requiresReloadOpt = this.requiresReloadOpts.find((opt) =>
+      event.affectsConfiguration(opt)
+    );
+
+    if (!requiresReloadOpt) return;
+
+    const userResponse = await vscode.window.showInformationMessage(
+      `Changing "${requiresReloadOpt}" requires a reload`,
+      "Reload now"
+    );
+
+    if (userResponse === "Reload now") {
+      await vscode.commands.executeCommand("workbench.action.reloadWindow");
     }
+  }
 
-    private refreshLogging() {
-        log.setEnabled(this.traceExtension);
-        log.info("Starting the Sway Language Client and Server");
-        log.info("Extension version:", this.package.version);
+  // We don't do runtime config validation here for simplicity. More on stackoverflow:
+  // https://stackoverflow.com/questions/60135780/what-is-the-best-way-to-type-check-the-configuration-for-vscode-extension
 
-        const cfg = Object.entries(this.cfg).filter(([_, val]) => !(val instanceof Function));
-        log.info("Using configuration", Object.fromEntries(cfg));
-    }
+  private get cfg(): vscode.WorkspaceConfiguration {
+    return vscode.workspace.getConfiguration(this.rootSection);
+  }
 
-    private async onDidChangeConfiguration(event: vscode.ConfigurationChangeEvent) {
-        this.refreshLogging();
+  /**
+   * Beware that postfix `!` operator erases both `null` and `undefined`.
+   * This is why the following doesn't work as expected:
+   *
+   * ```ts
+   * const nullableNum = vscode
+   *  .workspace
+   *  .getConfiguration
+   *  .getConfiguration("sway-lsp")
+   *  .get<number | null>(path)!;
+   *
+   * // What happens is that type of `nullableNum` is `number` but not `null | number`:
+   * const fullFledgedNum: number = nullableNum;
+   * ```
+   * So this getter handles this quirk by not requiring the caller to use postfix `!`
+   */
+  private get<T>(path: string): T {
+    return this.cfg.get<T>(path)!;
+  }
 
-        const requiresReloadOpt = this.requiresReloadOpts.find(
-            opt => event.affectsConfiguration(opt)
-        );
+  get traceExtension() {
+    return this.get<boolean>("trace.extension");
+  }
 
-        if (!requiresReloadOpt) return;
-
-        const userResponse = await vscode.window.showInformationMessage(
-            `Changing "${requiresReloadOpt}" requires a reload`,
-            "Reload now"
-        );
-
-        if (userResponse === "Reload now") {
-            await vscode.commands.executeCommand("workbench.action.reloadWindow");
-        }
-    }
-
-    // We don't do runtime config validation here for simplicity. More on stackoverflow:
-    // https://stackoverflow.com/questions/60135780/what-is-the-best-way-to-type-check-the-configuration-for-vscode-extension
-
-    private get cfg(): vscode.WorkspaceConfiguration {
-        return vscode.workspace.getConfiguration(this.rootSection);
-    }
-
-    /**
-     * Beware that postfix `!` operator erases both `null` and `undefined`.
-     * This is why the following doesn't work as expected:
-     *
-     * ```ts
-     * const nullableNum = vscode
-     *  .workspace
-     *  .getConfiguration
-     *  .getConfiguration("sway-lsp")
-     *  .get<number | null>(path)!;
-     *
-     * // What happens is that type of `nullableNum` is `number` but not `null | number`:
-     * const fullFledgedNum: number = nullableNum;
-     * ```
-     * So this getter handles this quirk by not requiring the caller to use postfix `!`
-     */
-    private get<T>(path: string): T {
-        return this.cfg.get<T>(path)!;
-    }
-
-    get traceExtension() { return this.get<boolean>("trace.extension"); }
-
-    get debug() {
-        return {
-            showParsedTokensAsWarnings: this.get<boolean>("debug.showParsedTokensAsWarnings")
-        }
-    }
+  get debug() {
+    return {
+      showParsedTokensAsWarnings: this.get<boolean>(
+        "debug.showParsedTokensAsWarnings"
+      ),
+    };
+  }
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
-import * as lc from 'vscode-languageclient/node';
-import { Config } from './config';
+import * as vscode from "vscode";
+import * as lc from "vscode-languageclient/node";
+import { Config } from "./config";
 import { log } from "./util";
 
 let client: lc.LanguageClient;
@@ -30,7 +30,10 @@ export function deactivate(): Thenable<void> | undefined {
   return client.stop();
 }
 
-function getServerOptions(context: vscode.ExtensionContext, config: Config): lc.ServerOptions {
+function getServerOptions(
+  context: vscode.ExtensionContext,
+  config: Config
+): lc.ServerOptions {
   let args = ["lsp"];
   if (config.debug.showParsedTokensAsWarnings) {
     args.push(" --parsed-tokens-as-warnings");

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,0 +1,46 @@
+import * as vscode from "vscode";
+import { inspect } from "util";
+
+export const log = new class {
+    private enabled = true;
+    private readonly output = vscode.window.createOutputChannel("Sway LSP Client");
+
+    setEnabled(yes: boolean): void {
+        log.enabled = yes;
+    }
+
+    // Hint: the type [T, ...T[]] means a non-empty array
+    debug(...msg: [unknown, ...unknown[]]): void {
+        if (!log.enabled) return;
+        log.write("DEBUG", ...msg);
+    }
+
+    info(...msg: [unknown, ...unknown[]]): void {
+        log.write("INFO", ...msg);
+    }
+
+    warn(...msg: [unknown, ...unknown[]]): void {
+        debugger;
+        log.write("WARN", ...msg);
+    }
+
+    error(...msg: [unknown, ...unknown[]]): void {
+        debugger;
+        log.write("ERROR", ...msg);
+        log.output.show(true);
+    }
+
+    private write(label: string, ...messageParts: unknown[]): void {
+        const message = messageParts.map(log.stringify).join(" ");
+        const dateTime = new Date().toLocaleString();
+        log.output.appendLine(`${label} [${dateTime}]: ${message}`);
+    }
+
+    private stringify(val: unknown): string {
+        if (typeof val === "string") return val;
+        return inspect(val, {
+            colors: false,
+            depth: 6, // heuristic
+        });
+    }
+};

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,46 +1,47 @@
 import * as vscode from "vscode";
 import { inspect } from "util";
 
-export const log = new class {
-    private enabled = true;
-    private readonly output = vscode.window.createOutputChannel("Sway LSP Client");
+export const log = new (class {
+  private enabled = true;
+  private readonly output =
+    vscode.window.createOutputChannel("Sway LSP Client");
 
-    setEnabled(yes: boolean): void {
-        log.enabled = yes;
-    }
+  setEnabled(yes: boolean): void {
+    log.enabled = yes;
+  }
 
-    // Hint: the type [T, ...T[]] means a non-empty array
-    debug(...msg: [unknown, ...unknown[]]): void {
-        if (!log.enabled) return;
-        log.write("DEBUG", ...msg);
-    }
+  // Hint: the type [T, ...T[]] means a non-empty array
+  debug(...msg: [unknown, ...unknown[]]): void {
+    if (!log.enabled) return;
+    log.write("DEBUG", ...msg);
+  }
 
-    info(...msg: [unknown, ...unknown[]]): void {
-        log.write("INFO", ...msg);
-    }
+  info(...msg: [unknown, ...unknown[]]): void {
+    log.write("INFO", ...msg);
+  }
 
-    warn(...msg: [unknown, ...unknown[]]): void {
-        debugger;
-        log.write("WARN", ...msg);
-    }
+  warn(...msg: [unknown, ...unknown[]]): void {
+    debugger;
+    log.write("WARN", ...msg);
+  }
 
-    error(...msg: [unknown, ...unknown[]]): void {
-        debugger;
-        log.write("ERROR", ...msg);
-        log.output.show(true);
-    }
+  error(...msg: [unknown, ...unknown[]]): void {
+    debugger;
+    log.write("ERROR", ...msg);
+    log.output.show(true);
+  }
 
-    private write(label: string, ...messageParts: unknown[]): void {
-        const message = messageParts.map(log.stringify).join(" ");
-        const dateTime = new Date().toLocaleString();
-        log.output.appendLine(`${label} [${dateTime}]: ${message}`);
-    }
+  private write(label: string, ...messageParts: unknown[]): void {
+    const message = messageParts.map(log.stringify).join(" ");
+    const dateTime = new Date().toLocaleString();
+    log.output.appendLine(`${label} [${dateTime}]: ${message}`);
+  }
 
-    private stringify(val: unknown): string {
-        if (typeof val === "string") return val;
-        return inspect(val, {
-            colors: false,
-            depth: 6, // heuristic
-        });
-    }
-};
+  private stringify(val: unknown): string {
+    if (typeof val === "string") return val;
+    return inspect(val, {
+      colors: false,
+      depth: 6, // heuristic
+    });
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "Snippets",
     "Themes"
   ],
-  "main": "./client/out/extension",
+  "main": "./client/out/main",
   "activationEvents": [
     "onLanguage:sway"
   ],
@@ -45,7 +45,22 @@
             "messages",
             "verbose"
           ],
+          "enumDescriptions": [
+            "No traces",
+            "Error only",
+            "Full log"
+          ],
           "default": "off"
+        },
+        "sway-lsp.trace.extension": {
+          "description": "Enable logging of the Sway VS Code extension itself.",
+          "type": "boolean",
+          "default": false
+        },
+        "sway-lsp.debug.showParsedTokensAsWarnings": {
+          "markdownDescription": "Show successfully parsed tokens by the sway-lsp server as warnings. If set to false, sway-lsp will revert to only showing warnings and errors reported by the compiler.",
+          "default": false,
+          "type": "boolean"
         }
       }
     },


### PR DESCRIPTION
Heavily inspired by how `rust-analyzer` has set up their Client. 

There are now two new options under the sway extension settings tab:

1. Sway-lsp > Trace: Extension:
If enabled, there is now a separate tab under the output window that shows logging coming from the Client itself. 

2. Sway-lsp -> Debug: Show Parsed Tokens As Warnings:
Shows all successfully parsed tokens by the server as warnings. See [this PR](https://github.com/FuelLabs/sway/pull/1148) for more details. When this checkbox is changed, a pop up window appears in the bottom right of VScode asking if the user would like to have the window refreshed for the changes to take effect. 