### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently it gets activated once you open a file with `.sw` extension.
 
 Prior to testing make sure you have [`forc`](https://github.com/FuelLabs/sway/tree/master/forc) installed as well.
 
-Ensure you have the `code` CLI tool installed by running `code --version`. If not, open the VSCode editor -> cmd + shift + p -> search `>Shell Command install` -> install.
+On macOS, ensure you have the `code` CLI tool installed by running `code --version`. If not, open the VSCode editor -> cmd + shift + p -> search `>Shell Command install` -> install. Additional information: <https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line>.
 
 ## Testing as a real installed extension
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Currently it gets activated once you open a file with `.sw` extension.
 
 Prior to testing make sure you have [`forc`](https://github.com/FuelLabs/sway/tree/master/forc) installed as well.
 
+Ensure you have the `code` CLI tool installed by running `code --version`. If not, open the VSCode editor -> cmd + shift + p -> search `>Shell Command install` -> install.
+
 ## Testing as a real installed extension
 
 ```sh


### PR DESCRIPTION
I ran into this error when running `npm run install-extension` because I didn't have `code` installed somehow. The error is misleading because I did have vsce 2.9.1 installed.

`The latest version of vsce is 2.9.1 and you have 2.5.3.` 