### PR TITLE
add break, continue, enum, and struct to keywords

### DIFF
--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -82,7 +82,7 @@
     {
       "comment": "Keyword",
       "name": "keyword.other.sway",
-      "match": "\\b(deref|let|ref|use|asm|dep)\\b"
+      "match": "\\b(break|continue|deref|enum|struct|let|ref|use|asm|dep)\\b"
     },
     {
       "include": "#sigils"


### PR DESCRIPTION
this solves part of #72. Still a few inconsistencies such as enum variant highlighting to solve before that issue can be closed. 