### PR TITLE
Add codelens for in-editor run button

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1,0 +1,29 @@
+import {
+  CancellationToken,
+  LanguageClient,
+  LanguageClientOptions,
+  LSPErrorCodes,
+  RequestType,
+  ServerOptions,
+} from 'vscode-languageclient/node';
+import { log, sleep } from './util';
+
+let client: LanguageClient | null;
+
+export const createClient = (
+  clientOptions: LanguageClientOptions,
+  serverOptions: ServerOptions
+): LanguageClient => {
+  if (client) {
+    throw new Error('Client already exists!');
+  }
+  client = new LanguageClient(
+    'sway-lsp',
+    'Sway Language Server',
+    serverOptions,
+    clientOptions
+  );
+  return client;
+};
+
+export const getClient = (): LanguageClient => client;

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1,12 +1,8 @@
 import {
-  CancellationToken,
   LanguageClient,
   LanguageClientOptions,
-  LSPErrorCodes,
-  RequestType,
   ServerOptions,
 } from 'vscode-languageclient/node';
-import { log, sleep } from './util';
 
 let client: LanguageClient | null;
 

--- a/client/src/code_lens/provider.ts
+++ b/client/src/code_lens/provider.ts
@@ -14,7 +14,7 @@ export class SwayCodeLensProvider implements CodeLensProvider {
     let forcRun: Command = {
       command: 'sway.runScript',
       title: '▶\u{fe0e} Run',
-      tooltip: 'Run the Sway script with Forc'
+      tooltip: 'Run the Sway script with Forc',
     };
 
     let forcRunLens = new CodeLens(topOfDocument, forcRun);

--- a/client/src/code_lens/provider.ts
+++ b/client/src/code_lens/provider.ts
@@ -2,9 +2,11 @@ import {
   CodeLens,
   CodeLensProvider,
   Command,
-  Range,
+  // Range,
   TextDocument,
 } from 'vscode';
+import { getRunnables } from '../interface/getRunnables';
+import { log } from '../util';
 
 export class SwayCodeLensProvider implements CodeLensProvider {
   async provideCodeLenses(document: TextDocument): Promise<CodeLens[]> {
@@ -12,11 +14,12 @@ export class SwayCodeLensProvider implements CodeLensProvider {
     let forcRun: Command = {
       command: 'sway.runScript',
       title: '▶\u{fe0e} Run',
+      
       tooltip: 'Run the Sway script with Forc',
     };
 
     // TODO: Get range of runnable function(s) from server
-    const runnableRanges = [new Range(0, 0, 0l, 0)]
+    const runnableRanges = await getRunnables(document.uri.path);// [new Range(0, 0, 0, 0)]
     const forcRunLenses = runnableRanges.map(range => new CodeLens(range, forcRun));
 
     return forcRunLenses;

--- a/client/src/code_lens/provider.ts
+++ b/client/src/code_lens/provider.ts
@@ -1,0 +1,24 @@
+import {
+  CodeLens,
+  CodeLensProvider,
+  Command,
+  Range,
+  TextDocument,
+} from 'vscode';
+
+export class SwayCodeLensProvider implements CodeLensProvider {
+  async provideCodeLenses(document: TextDocument): Promise<CodeLens[]> {
+    // TODO: Get range of runnable function from server
+    let topOfDocument = new Range(0, 0, 0, 0);
+
+    let forcRun: Command = {
+      command: 'sway.runScript',
+      title: '▶\u{fe0e} Run',
+      tooltip: 'Run the Sway script with Forc'
+    };
+
+    let forcRunLens = new CodeLens(topOfDocument, forcRun);
+
+    return [forcRunLens];
+  }
+}

--- a/client/src/code_lens/provider.ts
+++ b/client/src/code_lens/provider.ts
@@ -16,7 +16,7 @@ export class SwayCodeLensProvider implements CodeLensProvider {
     };
 
     // TODO: Get range of runnable function(s) from server
-    const runnableRanges = [new Range(0, 0, 0, 0)]
+    const runnableRanges = [new Range(0, 0, 0l, 0)]
     const forcRunLenses = runnableRanges.map(range => new CodeLens(range, forcRun));
 
     return forcRunLenses;

--- a/client/src/code_lens/provider.ts
+++ b/client/src/code_lens/provider.ts
@@ -1,14 +1,8 @@
-import {
-  CodeLens,
-  CodeLensProvider,
-  Command,
-  TextDocument,
-} from 'vscode';
+import { CodeLens, CodeLensProvider, Command, TextDocument } from 'vscode';
 import { getRunnables } from '../interface/getRunnables';
 
 export class SwayCodeLensProvider implements CodeLensProvider {
   async provideCodeLenses(document: TextDocument): Promise<CodeLens[]> {
-
     let forcRun: Command = {
       command: 'sway.runScript',
       title: '▶\u{fe0e} Run',
@@ -16,7 +10,9 @@ export class SwayCodeLensProvider implements CodeLensProvider {
     };
 
     const runnableRanges = await getRunnables();
-    const forcRunLenses = runnableRanges.map(range => new CodeLens(range, forcRun));
+    const forcRunLenses = runnableRanges.map(
+      range => new CodeLens(range, forcRun)
+    );
 
     return forcRunLenses;
   }

--- a/client/src/code_lens/provider.ts
+++ b/client/src/code_lens/provider.ts
@@ -8,8 +8,6 @@ import {
 
 export class SwayCodeLensProvider implements CodeLensProvider {
   async provideCodeLenses(document: TextDocument): Promise<CodeLens[]> {
-    // TODO: Get range of runnable function from server
-    let topOfDocument = new Range(0, 0, 0, 0);
 
     let forcRun: Command = {
       command: 'sway.runScript',
@@ -17,8 +15,10 @@ export class SwayCodeLensProvider implements CodeLensProvider {
       tooltip: 'Run the Sway script with Forc',
     };
 
-    let forcRunLens = new CodeLens(topOfDocument, forcRun);
+    // TODO: Get range of runnable function(s) from server
+    const runnableRanges = [new Range(0, 0, 0, 0)]
+    const forcRunLenses = runnableRanges.map(range => new CodeLens(range, forcRun));
 
-    return [forcRunLens];
+    return forcRunLenses;
   }
 }

--- a/client/src/code_lens/provider.ts
+++ b/client/src/code_lens/provider.ts
@@ -2,11 +2,9 @@ import {
   CodeLens,
   CodeLensProvider,
   Command,
-  // Range,
   TextDocument,
 } from 'vscode';
 import { getRunnables } from '../interface/getRunnables';
-import { log } from '../util';
 
 export class SwayCodeLensProvider implements CodeLensProvider {
   async provideCodeLenses(document: TextDocument): Promise<CodeLens[]> {
@@ -14,12 +12,10 @@ export class SwayCodeLensProvider implements CodeLensProvider {
     let forcRun: Command = {
       command: 'sway.runScript',
       title: '▶\u{fe0e} Run',
-      
-      tooltip: 'Run the Sway script with Forc',
+      tooltip: 'Run the Sway program with Forc',
     };
 
-    // TODO: Get range of runnable function(s) from server
-    const runnableRanges = await getRunnables(document.uri.path);// [new Range(0, 0, 0, 0)]
+    const runnableRanges = await getRunnables();
     const forcRunLenses = runnableRanges.map(range => new CodeLens(range, forcRun));
 
     return forcRunLenses;

--- a/client/src/interface/getRunnables.ts
+++ b/client/src/interface/getRunnables.ts
@@ -1,16 +1,16 @@
-import { RequestType } from "vscode-languageclient/node";
-import { getClient } from "../client";
+import { RequestType } from 'vscode-languageclient/node';
+import { getClient } from '../client';
 import { Range } from 'vscode';
 
 export interface GetRunnablesParams {}
 
 const request = new RequestType<GetRunnablesParams, Range[], void>(
-    "sway/runnables"
+  'sway/runnables'
 );
 
 export const getRunnables = async (): Promise<Range[]> => {
-    const client = getClient();
-    const params: GetRunnablesParams = {};
-    const response = await client.sendRequest(request, params);
-    return response ?? [];
-}
+  const client = getClient();
+  const params: GetRunnablesParams = {};
+  const response = await client.sendRequest(request, params);
+  return response ?? [];
+};

--- a/client/src/interface/getRunnables.ts
+++ b/client/src/interface/getRunnables.ts
@@ -1,0 +1,21 @@
+import { RequestType, TextDocumentIdentifier } from "vscode-languageclient/node";
+import { getClient } from "../client";
+import { log } from "../util";
+import { Range } from 'vscode';
+
+export interface GetRunnablesParams {
+    path: string;
+}
+
+const request = new RequestType<GetRunnablesParams, Range[], void>(
+    "sway/get_runnables"
+);
+
+export const getRunnables = async (path: string): Promise<Range[]> => {
+    const client = getClient();
+    const params: GetRunnablesParams = { path };
+    const response = await client.sendRequest(request, params);
+
+    log.info(`getRunnables response! ${response}`);
+    return response;
+}

--- a/client/src/interface/getRunnables.ts
+++ b/client/src/interface/getRunnables.ts
@@ -1,21 +1,16 @@
-import { RequestType, TextDocumentIdentifier } from "vscode-languageclient/node";
+import { RequestType } from "vscode-languageclient/node";
 import { getClient } from "../client";
-import { log } from "../util";
 import { Range } from 'vscode';
 
-export interface GetRunnablesParams {
-    path: string;
-}
+export interface GetRunnablesParams {}
 
 const request = new RequestType<GetRunnablesParams, Range[], void>(
-    "sway/get_runnables"
+    "sway/runnable"
 );
 
-export const getRunnables = async (path: string): Promise<Range[]> => {
+export const getRunnables = async (): Promise<Range[]> => {
     const client = getClient();
-    const params: GetRunnablesParams = { path };
+    const params: GetRunnablesParams = {};
     const response = await client.sendRequest(request, params);
-
-    log.info(`getRunnables response! ${response}`);
-    return response;
+    return response ?? [];
 }

--- a/client/src/interface/getRunnables.ts
+++ b/client/src/interface/getRunnables.ts
@@ -5,7 +5,7 @@ import { Range } from 'vscode';
 export interface GetRunnablesParams {}
 
 const request = new RequestType<GetRunnablesParams, Range[], void>(
-    "sway/runnable"
+    "sway/runnables"
 );
 
 export const getRunnables = async (): Promise<Range[]> => {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -14,14 +14,10 @@ import {
   ExtensionContext,
   ExtensionMode,
   languages,
-  Range,
-  SnippetString,
   window,
   workspace,
   WorkspaceConfiguration,
 } from 'vscode';
-
-let client: lc.LanguageClient;
 
 export function activate(context: ExtensionContext) {
   const config = new Config(context);
@@ -77,11 +73,9 @@ export function activate(context: ExtensionContext) {
     )
   );
 
-  client = new lc.LanguageClient(
-    'sway-lsp',
-    'Sway Language Server',
+  const client = createClient(
+    getClientOptions(),
     getServerOptions(context, config),
-    getClientOptions()
   );
 
   // Start the client. This will also launch the server

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,4 +1,3 @@
-import * as vscode from 'vscode';
 import * as lc from 'vscode-languageclient/node';
 import { Config } from './config';
 import { log } from './util';
@@ -7,52 +6,74 @@ import { Program, Function, ProgramProvider } from './program';
 import * as path from 'path';
 import forcRun from './commands/forcRun';
 
+import { createClient, getClient } from './client';
+import { SwayCodeLensProvider } from './code_lens/provider';
+import {
+  commands,
+  DocumentSelector,
+  ExtensionContext,
+  ExtensionMode,
+  languages,
+  Range,
+  SnippetString,
+  window,
+  workspace,
+  WorkspaceConfiguration,
+} from 'vscode';
+
 let client: lc.LanguageClient;
 
-export function activate(context: vscode.ExtensionContext) {
+export function activate(context: ExtensionContext) {
   const config = new Config(context);
+
+  // Register code lenses
+  let documentSelector: DocumentSelector = {
+    language: 'sway',
+    scheme: 'file',
+  };
+  let swayCodeLensProviderDisposable = languages.registerCodeLensProvider(
+    documentSelector,
+    new SwayCodeLensProvider()
+  );
+  context.subscriptions.push(swayCodeLensProviderDisposable);
 
   // Register tree views
   const rootPath =
-    vscode.workspace.workspaceFolders &&
-    vscode.workspace.workspaceFolders.length > 0
-      ? vscode.workspace.workspaceFolders[0].uri.fsPath
+    workspace.workspaceFolders && workspace.workspaceFolders.length > 0
+      ? workspace.workspaceFolders[0].uri.fsPath
       : undefined;
-  const contractProvider = vscode.window.registerTreeDataProvider(
+  const contractProvider = window.registerTreeDataProvider(
     'contracts',
     new ProgramProvider(rootPath, 'contract')
   );
-  vscode.window.registerTreeDataProvider(
+  window.registerTreeDataProvider(
     'scripts',
     new ProgramProvider(rootPath, 'script')
   );
-  vscode.window.registerTreeDataProvider(
+  window.registerTreeDataProvider(
     'predicates',
     new ProgramProvider(rootPath, 'predicate')
   );
-  vscode.commands.registerCommand(
+  commands.registerCommand(
     'programs.refreshEntry',
     (provider: ProgramProvider) => provider.refresh()
   );
-  vscode.commands.registerCommand('programs.editEntry', (contract: Program) =>
-    vscode.workspace.openTextDocument(contract.sourceFilePath).then(doc => {
-      vscode.window.showTextDocument(doc);
+  commands.registerCommand('programs.editEntry', (contract: Program) =>
+    workspace.openTextDocument(contract.sourceFilePath).then(doc => {
+      window.showTextDocument(doc);
     })
   );
-  vscode.commands.registerCommand(
-    'programs.run',
-    (runnableFunction: Function) => {
-      vscode.window.showInformationMessage(`Running ${runnableFunction.label}`);
-      const forcDir = path.parse(runnableFunction.sourceFilePath).dir;
-      forcRun(config, forcDir);
-    }
-  );
+  commands.registerCommand('programs.run', (runnableFunction: Function) => {
+    window.showInformationMessage(`Running ${runnableFunction.label}`);
+    const forcDir = path.parse(runnableFunction.sourceFilePath).dir;
+    forcRun(config, forcDir);
+  });
 
   // Register all command palettes
   const commandPalettes = new CommandPalettes(config).get();
   context.subscriptions.push(
     ...commandPalettes.map(({ command, callback }) =>
-      vscode.commands.registerCommand(command, callback)
+      commands.registerCommand(command, callback)
     )
   );
 
@@ -72,6 +93,7 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate(): Thenable<void> | undefined {
+  const client = getClient();
   if (!client) {
     return undefined;
   }
@@ -79,7 +101,7 @@ export function deactivate(): Thenable<void> | undefined {
 }
 
 function getServerOptions(
-  context: vscode.ExtensionContext,
+  context: ExtensionContext,
   config: Config
 ): lc.ServerOptions {
   let args = ['lsp'];
@@ -102,8 +124,8 @@ function getServerOptions(
   };
 
   switch (context.extensionMode) {
-    case vscode.ExtensionMode.Development:
-    case vscode.ExtensionMode.Test:
+    case ExtensionMode.Development:
+    case ExtensionMode.Test:
       return devServerOptions;
 
     default:
@@ -123,8 +145,8 @@ function getClientOptions(): lc.LanguageClientOptions {
     synchronize: {
       // Notify the server about file changes to *.sw files contained in the workspace
       fileEvents: [
-        vscode.workspace.createFileSystemWatcher('**/.sw'),
-        vscode.workspace.createFileSystemWatcher('**/*.sw'),
+        workspace.createFileSystemWatcher('**/.sw'),
+        workspace.createFileSystemWatcher('**/*.sw'),
       ],
     },
     initializationOptions: {
@@ -162,9 +184,9 @@ function getSwayConfigOptions(): SwayConfig {
   }
 }
 
-function getSwayFormattingOptions(): vscode.WorkspaceConfiguration | null {
-  const swayOptions = vscode.workspace.getConfiguration('sway');
-  const swayOptionsBracket = vscode.workspace.getConfiguration('[sway]');
+function getSwayFormattingOptions(): WorkspaceConfiguration | null {
+  const swayOptions = workspace.getConfiguration('sway');
+  const swayOptionsBracket = workspace.getConfiguration('[sway]');
 
   if (swayOptions && swayOptions.format) {
     if (swayOptionsBracket && swayOptionsBracket.format) {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -75,7 +75,7 @@ export function activate(context: ExtensionContext) {
 
   const client = createClient(
     getClientOptions(),
-    getServerOptions(context, config),
+    getServerOptions(context, config)
   );
 
   // Start the client. This will also launch the server

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -45,7 +45,3 @@ export const log = new (class {
     });
   }
 })();
-
-export function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -45,3 +45,7 @@ export const log = new (class {
     });
   }
 })();
+
+export function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
This adds a Run button above every runnable function (defined by the LSP server). When clicked, it runs `forc run` on the file.

In the future, we can distinguish between main functions and test functions, which could also be runnable.

![Aug-01-2022 17-43-13](https://user-images.githubusercontent.com/47993817/182268231-19ea2ab8-c6d9-4eec-bfe3-2a6a5fde7adb.gif)

Fixes https://github.com/FuelLabs/sway-vscode-plugin/issues/54

Related https://github.com/FuelLabs/sway/pull/2441