### PR TITLE
Make syntax highlighting more similar to Rust

### DIFF
--- a/client/test/syntaxes/basic_predicate.sw
+++ b/client/test/syntaxes/basic_predicate.sw
@@ -1,0 +1,5 @@
+predicate;
+
+fn main() -> bool {
+    true
+}

--- a/client/test/syntaxes/basic_predicate.sw.snap
+++ b/client/test/syntaxes/basic_predicate.sw.snap
@@ -1,0 +1,22 @@
+>predicate;
+#^^^^^^^^^ source.sway storage.type.sway
+#         ^ source.sway
+>
+>fn main() -> bool {
+#^^ source.sway meta.function.definition.sway keyword.other.fn.sway
+#  ^ source.sway meta.function.definition.sway
+#   ^^^^ source.sway meta.function.definition.sway entity.name.function.sway
+#       ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#        ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#         ^ source.sway meta.function.definition.sway
+#          ^^ source.sway meta.function.definition.sway keyword.operator.arrow.skinny.sway
+#            ^ source.sway meta.function.definition.sway
+#             ^^^^ source.sway meta.function.definition.sway entity.name.type.primitive.sway
+#                 ^ source.sway meta.function.definition.sway
+#                  ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
+>    true
+#^^^^ source.sway
+#    ^^^^ source.sway constant.language.bool.sway
+>}
+#^ source.sway punctuation.brackets.curly.sway
+>

--- a/client/test/syntaxes/basic_predicate.sw.snap
+++ b/client/test/syntaxes/basic_predicate.sw.snap
@@ -1,5 +1,5 @@
 >predicate;
-#^^^^^^^^^ source.sway storage.type.sway
+#^^^^^^^^^ source.sway source.sway meta.attribute.sway
 #         ^ source.sway
 >
 >fn main() -> bool {

--- a/client/test/syntaxes/chained_if_let.sw
+++ b/client/test/syntaxes/chained_if_let.sw
@@ -1,0 +1,22 @@
+script;
+
+enum Result<T, E> {
+    Ok: T,
+    Err: E,
+}
+
+// should return 5
+fn main() -> u64 {
+    let result_a = Result::Ok::<u64, bool>(5u64);
+    let result_b = Result::Err::<u64, bool>(false);
+
+    if let Result::Err(a) = result_a {
+        6
+    } else if let Result::Ok(num) = result_b {
+        10
+    } else if let Result::Ok(num) = result_a {
+        num
+    } else {
+        42
+    }
+}

--- a/client/test/syntaxes/chained_if_let.sw.snap
+++ b/client/test/syntaxes/chained_if_let.sw.snap
@@ -1,5 +1,5 @@
 >script;
-#^^^^^^ source.sway storage.type.sway
+#^^^^^^ source.sway source.sway meta.attribute.sway
 #      ^ source.sway
 >
 >enum Result<T, E> {

--- a/client/test/syntaxes/chained_if_let.sw.snap
+++ b/client/test/syntaxes/chained_if_let.sw.snap
@@ -1,0 +1,180 @@
+>script;
+#^^^^^^ source.sway storage.type.sway
+#      ^ source.sway
+>
+>enum Result<T, E> {
+#^^^^ source.sway keyword.declaration.enum.sway storage.type.sway
+#    ^ source.sway
+#     ^^^^^^ source.sway entity.name.type.enum.sway
+#           ^ source.sway punctuation.brackets.angle.sway
+#            ^ source.sway entity.name.type.sway
+#             ^ source.sway punctuation.comma.sway
+#              ^ source.sway
+#               ^ source.sway entity.name.type.sway
+#                ^ source.sway punctuation.brackets.angle.sway
+#                 ^ source.sway
+#                  ^ source.sway punctuation.brackets.curly.sway
+>    Ok: T,
+#^^^^ source.sway
+#    ^^ source.sway entity.name.type.result.sway
+#      ^ source.sway keyword.operator.key-value.sway
+#       ^ source.sway
+#        ^ source.sway entity.name.type.sway
+#         ^ source.sway punctuation.comma.sway
+>    Err: E,
+#^^^^ source.sway
+#    ^^^ source.sway entity.name.type.result.sway
+#       ^ source.sway keyword.operator.key-value.sway
+#        ^ source.sway
+#         ^ source.sway entity.name.type.sway
+#          ^ source.sway punctuation.comma.sway
+>}
+#^ source.sway punctuation.brackets.curly.sway
+>
+>// should return 5
+#^^^^^^^^^^^^^^^^^^ source.sway comment.line.double-slash.sway
+>fn main() -> u64 {
+#^^ source.sway meta.function.definition.sway keyword.other.fn.sway
+#  ^ source.sway meta.function.definition.sway
+#   ^^^^ source.sway meta.function.definition.sway entity.name.function.sway
+#       ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#        ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#         ^ source.sway meta.function.definition.sway
+#          ^^ source.sway meta.function.definition.sway keyword.operator.arrow.skinny.sway
+#            ^ source.sway meta.function.definition.sway
+#             ^^^ source.sway meta.function.definition.sway entity.name.type.numeric.sway
+#                ^ source.sway meta.function.definition.sway
+#                 ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
+>    let result_a = Result::Ok::<u64, bool>(5u64);
+#^^^^ source.sway
+#    ^^^ source.sway keyword.other.sway storage.type.sway
+#       ^ source.sway
+#        ^^^^^^^^ source.sway variable.other.sway
+#                ^ source.sway
+#                 ^ source.sway keyword.operator.assignment.equal.sway
+#                  ^ source.sway
+#                   ^^^^^^ source.sway entity.name.type.sway
+#                         ^^ source.sway keyword.operator.namespace.sway
+#                           ^^ source.sway entity.name.type.result.sway
+#                             ^^ source.sway keyword.operator.namespace.sway
+#                               ^ source.sway punctuation.brackets.angle.sway
+#                                ^^^ source.sway entity.name.type.numeric.sway
+#                                   ^ source.sway punctuation.comma.sway
+#                                    ^ source.sway
+#                                     ^^^^ source.sway entity.name.type.primitive.sway
+#                                         ^ source.sway punctuation.brackets.angle.sway
+#                                          ^ source.sway punctuation.brackets.round.sway
+#                                           ^ source.sway constant.numeric.decimal.sway
+#                                            ^^^ source.sway constant.numeric.decimal.sway entity.name.type.numeric.sway
+#                                               ^ source.sway punctuation.brackets.round.sway
+#                                                ^ source.sway punctuation.semi.sway
+>    let result_b = Result::Err::<u64, bool>(false);
+#^^^^ source.sway
+#    ^^^ source.sway keyword.other.sway storage.type.sway
+#       ^ source.sway
+#        ^^^^^^^^ source.sway variable.other.sway
+#                ^ source.sway
+#                 ^ source.sway keyword.operator.assignment.equal.sway
+#                  ^ source.sway
+#                   ^^^^^^ source.sway entity.name.type.sway
+#                         ^^ source.sway keyword.operator.namespace.sway
+#                           ^^^ source.sway entity.name.type.result.sway
+#                              ^^ source.sway keyword.operator.namespace.sway
+#                                ^ source.sway punctuation.brackets.angle.sway
+#                                 ^^^ source.sway entity.name.type.numeric.sway
+#                                    ^ source.sway punctuation.comma.sway
+#                                     ^ source.sway
+#                                      ^^^^ source.sway entity.name.type.primitive.sway
+#                                          ^ source.sway punctuation.brackets.angle.sway
+#                                           ^ source.sway punctuation.brackets.round.sway
+#                                            ^^^^^ source.sway constant.language.bool.sway
+#                                                 ^ source.sway punctuation.brackets.round.sway
+#                                                  ^ source.sway punctuation.semi.sway
+>
+>    if let Result::Err(a) = result_a {
+#^^^^ source.sway
+#    ^^ source.sway keyword.control.sway
+#      ^ source.sway
+#       ^^^ source.sway keyword.other.sway storage.type.sway
+#          ^ source.sway
+#           ^^^^^^ source.sway entity.name.type.sway
+#                 ^^ source.sway keyword.operator.namespace.sway
+#                   ^^^ source.sway entity.name.type.result.sway
+#                      ^ source.sway punctuation.brackets.round.sway
+#                       ^ source.sway variable.other.sway
+#                        ^ source.sway punctuation.brackets.round.sway
+#                         ^ source.sway
+#                          ^ source.sway keyword.operator.assignment.equal.sway
+#                           ^ source.sway
+#                            ^^^^^^^^ source.sway variable.other.sway
+#                                    ^ source.sway
+#                                     ^ source.sway punctuation.brackets.curly.sway
+>        6
+#^^^^^^^^ source.sway
+#        ^ source.sway constant.numeric.decimal.sway
+>    } else if let Result::Ok(num) = result_b {
+#^^^^ source.sway
+#    ^ source.sway punctuation.brackets.curly.sway
+#     ^ source.sway
+#      ^^^^ source.sway keyword.control.sway
+#          ^ source.sway
+#           ^^ source.sway keyword.control.sway
+#             ^ source.sway
+#              ^^^ source.sway keyword.other.sway storage.type.sway
+#                 ^ source.sway
+#                  ^^^^^^ source.sway entity.name.type.sway
+#                        ^^ source.sway keyword.operator.namespace.sway
+#                          ^^ source.sway entity.name.type.result.sway
+#                            ^ source.sway punctuation.brackets.round.sway
+#                             ^^^ source.sway variable.other.sway
+#                                ^ source.sway punctuation.brackets.round.sway
+#                                 ^ source.sway
+#                                  ^ source.sway keyword.operator.assignment.equal.sway
+#                                   ^ source.sway
+#                                    ^^^^^^^^ source.sway variable.other.sway
+#                                            ^ source.sway
+#                                             ^ source.sway punctuation.brackets.curly.sway
+>        10
+#^^^^^^^^ source.sway
+#        ^^ source.sway constant.numeric.decimal.sway
+>    } else if let Result::Ok(num) = result_a {
+#^^^^ source.sway
+#    ^ source.sway punctuation.brackets.curly.sway
+#     ^ source.sway
+#      ^^^^ source.sway keyword.control.sway
+#          ^ source.sway
+#           ^^ source.sway keyword.control.sway
+#             ^ source.sway
+#              ^^^ source.sway keyword.other.sway storage.type.sway
+#                 ^ source.sway
+#                  ^^^^^^ source.sway entity.name.type.sway
+#                        ^^ source.sway keyword.operator.namespace.sway
+#                          ^^ source.sway entity.name.type.result.sway
+#                            ^ source.sway punctuation.brackets.round.sway
+#                             ^^^ source.sway variable.other.sway
+#                                ^ source.sway punctuation.brackets.round.sway
+#                                 ^ source.sway
+#                                  ^ source.sway keyword.operator.assignment.equal.sway
+#                                   ^ source.sway
+#                                    ^^^^^^^^ source.sway variable.other.sway
+#                                            ^ source.sway
+#                                             ^ source.sway punctuation.brackets.curly.sway
+>        num
+#^^^^^^^^ source.sway
+#        ^^^ source.sway variable.other.sway
+>    } else {
+#^^^^ source.sway
+#    ^ source.sway punctuation.brackets.curly.sway
+#     ^ source.sway
+#      ^^^^ source.sway keyword.control.sway
+#          ^ source.sway
+#           ^ source.sway punctuation.brackets.curly.sway
+>        42
+#^^^^^^^^ source.sway
+#        ^^ source.sway constant.numeric.decimal.sway
+>    }
+#^^^^ source.sway
+#    ^ source.sway punctuation.brackets.curly.sway
+>}
+#^ source.sway punctuation.brackets.curly.sway
+>

--- a/client/test/syntaxes/chained_if_let.sw.snap
+++ b/client/test/syntaxes/chained_if_let.sw.snap
@@ -3,7 +3,7 @@
 #      ^ source.sway
 >
 >enum Result<T, E> {
-#^^^^ source.sway keyword.declaration.enum.sway storage.type.sway
+#^^^^ source.sway keyword.declaration.enum.sway
 #    ^ source.sway
 #     ^^^^^^ source.sway entity.name.type.enum.sway
 #           ^ source.sway punctuation.brackets.angle.sway
@@ -47,7 +47,7 @@
 #                 ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
 >    let result_a = Result::Ok::<u64, bool>(5u64);
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway storage.type.sway
+#    ^^^ source.sway storage.modifier.sway
 #       ^ source.sway
 #        ^^^^^^^^ source.sway variable.other.sway
 #                ^ source.sway
@@ -70,7 +70,7 @@
 #                                                ^ source.sway punctuation.semi.sway
 >    let result_b = Result::Err::<u64, bool>(false);
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway storage.type.sway
+#    ^^^ source.sway storage.modifier.sway
 #       ^ source.sway
 #        ^^^^^^^^ source.sway variable.other.sway
 #                ^ source.sway
@@ -95,7 +95,7 @@
 #^^^^ source.sway
 #    ^^ source.sway keyword.control.sway
 #      ^ source.sway
-#       ^^^ source.sway keyword.other.sway storage.type.sway
+#       ^^^ source.sway storage.modifier.sway
 #          ^ source.sway
 #           ^^^^^^ source.sway entity.name.type.sway
 #                 ^^ source.sway keyword.operator.namespace.sway
@@ -120,7 +120,7 @@
 #          ^ source.sway
 #           ^^ source.sway keyword.control.sway
 #             ^ source.sway
-#              ^^^ source.sway keyword.other.sway storage.type.sway
+#              ^^^ source.sway storage.modifier.sway
 #                 ^ source.sway
 #                  ^^^^^^ source.sway entity.name.type.sway
 #                        ^^ source.sway keyword.operator.namespace.sway
@@ -145,7 +145,7 @@
 #          ^ source.sway
 #           ^^ source.sway keyword.control.sway
 #             ^ source.sway
-#              ^^^ source.sway keyword.other.sway storage.type.sway
+#              ^^^ source.sway storage.modifier.sway
 #                 ^ source.sway
 #                  ^^^^^^ source.sway entity.name.type.sway
 #                        ^^ source.sway keyword.operator.namespace.sway

--- a/client/test/syntaxes/const_decl.sw.snap
+++ b/client/test/syntaxes/const_decl.sw.snap
@@ -3,32 +3,47 @@
 #      ^ source.sway
 >
 >const GLOBAL_VAL: u64 = 99;
-#^^^^^^^^^^^^^^^^^^ source.sway
-#                  ^^^ source.sway support.type.primitive.sway
+#^^^^^ source.sway storage.type.sway
+#     ^ source.sway
+#      ^^^^^^^^^^ source.sway constant.other.caps.sway
+#                ^ source.sway keyword.operator.key-value.sway
+#                 ^ source.sway
+#                  ^^^ source.sway entity.name.type.numeric.sway
 #                     ^ source.sway
-#                      ^ source.sway keyword.operator.assignment.sway
+#                      ^ source.sway keyword.operator.assignment.equal.sway
 #                       ^ source.sway
-#                        ^^ source.sway constant.numeric.integer.sway
-#                          ^^ source.sway
+#                        ^^ source.sway constant.numeric.decimal.sway
+#                          ^ source.sway punctuation.semi.sway
 >
 >fn main() -> u64 {
-#^^ source.sway keyword.other.fn.sway
-#  ^ source.sway
-#   ^^^^ source.sway entity.name.function.sway
-#       ^^^^^^ source.sway
-#             ^^^ source.sway support.type.primitive.sway
-#                ^ source.sway
-#                 ^ source.sway
+#^^ source.sway meta.function.definition.sway keyword.other.fn.sway
+#  ^ source.sway meta.function.definition.sway
+#   ^^^^ source.sway meta.function.definition.sway entity.name.function.sway
+#       ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#        ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#         ^ source.sway meta.function.definition.sway
+#          ^^ source.sway meta.function.definition.sway keyword.operator.arrow.skinny.sway
+#            ^ source.sway meta.function.definition.sway
+#             ^^^ source.sway meta.function.definition.sway entity.name.type.numeric.sway
+#                ^ source.sway meta.function.definition.sway
+#                 ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
 >    const LOCAL_VAL = 1;
-#^^^^^^^^^^^^^^^^^^^^ source.sway
-#                    ^ source.sway keyword.operator.assignment.sway
+#^^^^ source.sway
+#    ^^^^^ source.sway storage.type.sway
+#         ^ source.sway
+#          ^^^^^^^^^ source.sway constant.other.caps.sway
+#                   ^ source.sway
+#                    ^ source.sway keyword.operator.assignment.equal.sway
 #                     ^ source.sway
-#                      ^ source.sway constant.numeric.integer.sway
-#                       ^^ source.sway
+#                      ^ source.sway constant.numeric.decimal.sway
+#                       ^ source.sway punctuation.semi.sway
 >    GLOBAL_VAL + LOCAL_VAL
-#^^^^^^^^^^^^^^^ source.sway
-#               ^ source.sway keyword.operator.arithmetic.sway
-#                ^^^^^^^^^^^ source.sway
+#^^^^ source.sway
+#    ^^^^^^^^^^ source.sway constant.other.caps.sway
+#              ^ source.sway
+#               ^ source.sway keyword.operator.math.sway
+#                ^ source.sway
+#                 ^^^^^^^^^ source.sway constant.other.caps.sway
 >}
-#^^ source.sway
+#^ source.sway punctuation.brackets.curly.sway
 >

--- a/client/test/syntaxes/const_decl.sw.snap
+++ b/client/test/syntaxes/const_decl.sw.snap
@@ -1,5 +1,5 @@
 >script;
-#^^^^^^ source.sway storage.type.sway
+#^^^^^^ source.sway source.sway meta.attribute.sway
 #      ^ source.sway
 >
 >const GLOBAL_VAL: u64 = 99;

--- a/client/test/syntaxes/match_expressions_mismatched.sw
+++ b/client/test/syntaxes/match_expressions_mismatched.sw
@@ -1,0 +1,24 @@
+script;
+
+struct MyStruct {
+    a: u64,
+    b: u64,
+}
+
+enum MyEnum {
+    Variant1: (),
+    Variant2: u64,
+    Variant3: MyStruct,
+}
+
+fn main() -> u64 {
+    let x = MyEnum::Variant1;
+    let y = MyEnum::Variant2(5);
+    let z = MyEnum::Variant3(MyStruct {
+        a: 0, b: 1
+    });
+
+    match y {
+        MyEnum::Variant2(y) => y, _ => 10, 
+    }
+}

--- a/client/test/syntaxes/match_expressions_mismatched.sw.snap
+++ b/client/test/syntaxes/match_expressions_mismatched.sw.snap
@@ -1,0 +1,164 @@
+>script;
+#^^^^^^ source.sway storage.type.sway
+#      ^ source.sway
+>
+>struct MyStruct {
+#^^^^^^ source.sway keyword.declaration.struct.sway storage.type.sway
+#      ^ source.sway
+#       ^^^^^^^^ source.sway entity.name.type.struct.sway
+#               ^ source.sway
+#                ^ source.sway punctuation.brackets.curly.sway
+>    a: u64,
+#^^^^ source.sway
+#    ^ source.sway variable.other.sway
+#     ^ source.sway keyword.operator.key-value.sway
+#      ^ source.sway
+#       ^^^ source.sway entity.name.type.numeric.sway
+#          ^ source.sway punctuation.comma.sway
+>    b: u64,
+#^^^^ source.sway
+#    ^ source.sway variable.other.sway
+#     ^ source.sway keyword.operator.key-value.sway
+#      ^ source.sway
+#       ^^^ source.sway entity.name.type.numeric.sway
+#          ^ source.sway punctuation.comma.sway
+>}
+#^ source.sway punctuation.brackets.curly.sway
+>
+>enum MyEnum {
+#^^^^ source.sway keyword.declaration.enum.sway storage.type.sway
+#    ^ source.sway
+#     ^^^^^^ source.sway entity.name.type.enum.sway
+#           ^ source.sway
+#            ^ source.sway punctuation.brackets.curly.sway
+>    Variant1: (),
+#^^^^ source.sway
+#    ^^^^^^^^ source.sway entity.name.type.sway
+#            ^ source.sway keyword.operator.key-value.sway
+#             ^ source.sway
+#              ^ source.sway punctuation.brackets.round.sway
+#               ^ source.sway punctuation.brackets.round.sway
+#                ^ source.sway punctuation.comma.sway
+>    Variant2: u64,
+#^^^^ source.sway
+#    ^^^^^^^^ source.sway entity.name.type.sway
+#            ^ source.sway keyword.operator.key-value.sway
+#             ^ source.sway
+#              ^^^ source.sway entity.name.type.numeric.sway
+#                 ^ source.sway punctuation.comma.sway
+>    Variant3: MyStruct,
+#^^^^ source.sway
+#    ^^^^^^^^ source.sway entity.name.type.sway
+#            ^ source.sway keyword.operator.key-value.sway
+#             ^ source.sway
+#              ^^^^^^^^ source.sway entity.name.type.sway
+#                      ^ source.sway punctuation.comma.sway
+>}
+#^ source.sway punctuation.brackets.curly.sway
+>
+>fn main() -> u64 {
+#^^ source.sway meta.function.definition.sway keyword.other.fn.sway
+#  ^ source.sway meta.function.definition.sway
+#   ^^^^ source.sway meta.function.definition.sway entity.name.function.sway
+#       ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#        ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#         ^ source.sway meta.function.definition.sway
+#          ^^ source.sway meta.function.definition.sway keyword.operator.arrow.skinny.sway
+#            ^ source.sway meta.function.definition.sway
+#             ^^^ source.sway meta.function.definition.sway entity.name.type.numeric.sway
+#                ^ source.sway meta.function.definition.sway
+#                 ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
+>    let x = MyEnum::Variant1;
+#^^^^ source.sway
+#    ^^^ source.sway keyword.other.sway storage.type.sway
+#       ^ source.sway
+#        ^ source.sway variable.other.sway
+#         ^ source.sway
+#          ^ source.sway keyword.operator.assignment.equal.sway
+#           ^ source.sway
+#            ^^^^^^ source.sway entity.name.type.sway
+#                  ^^ source.sway keyword.operator.namespace.sway
+#                    ^^^^^^^^ source.sway entity.name.type.sway
+#                            ^ source.sway punctuation.semi.sway
+>    let y = MyEnum::Variant2(5);
+#^^^^ source.sway
+#    ^^^ source.sway keyword.other.sway storage.type.sway
+#       ^ source.sway
+#        ^ source.sway variable.other.sway
+#         ^ source.sway
+#          ^ source.sway keyword.operator.assignment.equal.sway
+#           ^ source.sway
+#            ^^^^^^ source.sway entity.name.type.sway
+#                  ^^ source.sway keyword.operator.namespace.sway
+#                    ^^^^^^^^ source.sway meta.function.call.sway entity.name.function.sway
+#                            ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
+#                             ^ source.sway meta.function.call.sway constant.numeric.decimal.sway
+#                              ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
+#                               ^ source.sway punctuation.semi.sway
+>    let z = MyEnum::Variant3(MyStruct {
+#^^^^ source.sway
+#    ^^^ source.sway keyword.other.sway storage.type.sway
+#       ^ source.sway
+#        ^ source.sway variable.other.sway
+#         ^ source.sway
+#          ^ source.sway keyword.operator.assignment.equal.sway
+#           ^ source.sway
+#            ^^^^^^ source.sway entity.name.type.sway
+#                  ^^ source.sway keyword.operator.namespace.sway
+#                    ^^^^^^^^ source.sway meta.function.call.sway entity.name.function.sway
+#                            ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
+#                             ^^^^^^^^ source.sway meta.function.call.sway entity.name.type.sway
+#                                     ^ source.sway meta.function.call.sway
+#                                      ^ source.sway meta.function.call.sway punctuation.brackets.curly.sway
+>        a: 0, b: 1
+#^^^^^^^^ source.sway meta.function.call.sway
+#        ^ source.sway meta.function.call.sway variable.other.sway
+#         ^ source.sway meta.function.call.sway keyword.operator.key-value.sway
+#          ^ source.sway meta.function.call.sway
+#           ^ source.sway meta.function.call.sway constant.numeric.decimal.sway
+#            ^ source.sway meta.function.call.sway punctuation.comma.sway
+#             ^ source.sway meta.function.call.sway
+#              ^ source.sway meta.function.call.sway variable.other.sway
+#               ^ source.sway meta.function.call.sway keyword.operator.key-value.sway
+#                ^ source.sway meta.function.call.sway
+#                 ^ source.sway meta.function.call.sway constant.numeric.decimal.sway
+>    });
+#^^^^ source.sway meta.function.call.sway
+#    ^ source.sway meta.function.call.sway punctuation.brackets.curly.sway
+#     ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
+#      ^ source.sway punctuation.semi.sway
+>
+>    match y {
+#^^^^ source.sway
+#    ^^^^^ source.sway keyword.control.sway
+#         ^ source.sway
+#          ^ source.sway variable.other.sway
+#           ^ source.sway
+#            ^ source.sway punctuation.brackets.curly.sway
+>        MyEnum::Variant2(y) => y, _ => 10, 
+#^^^^^^^^ source.sway
+#        ^^^^^^ source.sway entity.name.type.sway
+#              ^^ source.sway keyword.operator.namespace.sway
+#                ^^^^^^^^ source.sway meta.function.call.sway entity.name.function.sway
+#                        ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
+#                         ^ source.sway meta.function.call.sway variable.other.sway
+#                          ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
+#                           ^ source.sway
+#                            ^^ source.sway keyword.operator.arrow.fat.sway
+#                              ^ source.sway
+#                               ^ source.sway variable.other.sway
+#                                ^ source.sway punctuation.comma.sway
+#                                 ^ source.sway
+#                                  ^ source.sway variable.other.sway
+#                                   ^ source.sway
+#                                    ^^ source.sway keyword.operator.arrow.fat.sway
+#                                      ^ source.sway
+#                                       ^^ source.sway constant.numeric.decimal.sway
+#                                         ^ source.sway punctuation.comma.sway
+#                                          ^^ source.sway
+>    }
+#^^^^ source.sway
+#    ^ source.sway punctuation.brackets.curly.sway
+>}
+#^ source.sway punctuation.brackets.curly.sway
+>

--- a/client/test/syntaxes/match_expressions_mismatched.sw.snap
+++ b/client/test/syntaxes/match_expressions_mismatched.sw.snap
@@ -1,5 +1,5 @@
 >script;
-#^^^^^^ source.sway storage.type.sway
+#^^^^^^ source.sway source.sway meta.attribute.sway
 #      ^ source.sway
 >
 >struct MyStruct {

--- a/client/test/syntaxes/match_expressions_mismatched.sw.snap
+++ b/client/test/syntaxes/match_expressions_mismatched.sw.snap
@@ -3,7 +3,7 @@
 #      ^ source.sway
 >
 >struct MyStruct {
-#^^^^^^ source.sway keyword.declaration.struct.sway storage.type.sway
+#^^^^^^ source.sway keyword.declaration.struct.sway
 #      ^ source.sway
 #       ^^^^^^^^ source.sway entity.name.type.struct.sway
 #               ^ source.sway
@@ -26,7 +26,7 @@
 #^ source.sway punctuation.brackets.curly.sway
 >
 >enum MyEnum {
-#^^^^ source.sway keyword.declaration.enum.sway storage.type.sway
+#^^^^ source.sway keyword.declaration.enum.sway
 #    ^ source.sway
 #     ^^^^^^ source.sway entity.name.type.enum.sway
 #           ^ source.sway
@@ -70,7 +70,7 @@
 #                 ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
 >    let x = MyEnum::Variant1;
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway storage.type.sway
+#    ^^^ source.sway storage.modifier.sway
 #       ^ source.sway
 #        ^ source.sway variable.other.sway
 #         ^ source.sway
@@ -82,7 +82,7 @@
 #                            ^ source.sway punctuation.semi.sway
 >    let y = MyEnum::Variant2(5);
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway storage.type.sway
+#    ^^^ source.sway storage.modifier.sway
 #       ^ source.sway
 #        ^ source.sway variable.other.sway
 #         ^ source.sway
@@ -97,7 +97,7 @@
 #                               ^ source.sway punctuation.semi.sway
 >    let z = MyEnum::Variant3(MyStruct {
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway storage.type.sway
+#    ^^^ source.sway storage.modifier.sway
 #       ^ source.sway
 #        ^ source.sway variable.other.sway
 #         ^ source.sway

--- a/client/test/syntaxes/particle.sw.snap
+++ b/client/test/syntaxes/particle.sw.snap
@@ -3,149 +3,260 @@
 #      ^ source.sway
 >
 >/// A simple Particle struct
-#^^^ source.sway comment.line.documentation.sway
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^ source.sway comment.line.documentation.sway
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sway comment.line.documentation.sway
 >pub struct Particle {
-#^^^ source.sway storage.modifier.visibility.sway
+#^^^ source.sway keyword.other.sway
 #   ^ source.sway
-#    ^^^^^^ source.sway keyword.other.sway
-#          ^^^^^^^^^^^^ source.sway
+#    ^^^^^^ source.sway keyword.declaration.struct.sway storage.type.sway
+#          ^ source.sway
+#           ^^^^^^^^ source.sway entity.name.type.struct.sway
+#                   ^ source.sway
+#                    ^ source.sway punctuation.brackets.curly.sway
 >    position: [u64; 3],
-#^^^^^^^^^^^^^^^ source.sway
-#               ^^^ source.sway support.type.primitive.sway
-#                  ^^ source.sway
-#                    ^ source.sway constant.numeric.integer.sway
-#                     ^^^ source.sway
+#^^^^ source.sway
+#    ^^^^^^^^ source.sway variable.other.sway
+#            ^ source.sway keyword.operator.key-value.sway
+#             ^ source.sway
+#              ^ source.sway punctuation.brackets.square.sway
+#               ^^^ source.sway entity.name.type.numeric.sway
+#                  ^ source.sway punctuation.semi.sway
+#                   ^ source.sway
+#                    ^ source.sway constant.numeric.decimal.sway
+#                     ^ source.sway punctuation.brackets.square.sway
+#                      ^ source.sway punctuation.comma.sway
 >    velocity: [u64; 3],
-#^^^^^^^^^^^^^^^ source.sway
-#               ^^^ source.sway support.type.primitive.sway
-#                  ^^ source.sway
-#                    ^ source.sway constant.numeric.integer.sway
-#                     ^^^ source.sway
+#^^^^ source.sway
+#    ^^^^^^^^ source.sway variable.other.sway
+#            ^ source.sway keyword.operator.key-value.sway
+#             ^ source.sway
+#              ^ source.sway punctuation.brackets.square.sway
+#               ^^^ source.sway entity.name.type.numeric.sway
+#                  ^ source.sway punctuation.semi.sway
+#                   ^ source.sway
+#                    ^ source.sway constant.numeric.decimal.sway
+#                     ^ source.sway punctuation.brackets.square.sway
+#                      ^ source.sway punctuation.comma.sway
 >    acceleration: [u64; 3],
-#^^^^^^^^^^^^^^^^^^^ source.sway
-#                   ^^^ source.sway support.type.primitive.sway
-#                      ^^ source.sway
-#                        ^ source.sway constant.numeric.integer.sway
-#                         ^^^ source.sway
+#^^^^ source.sway
+#    ^^^^^^^^^^^^ source.sway variable.other.sway
+#                ^ source.sway keyword.operator.key-value.sway
+#                 ^ source.sway
+#                  ^ source.sway punctuation.brackets.square.sway
+#                   ^^^ source.sway entity.name.type.numeric.sway
+#                      ^ source.sway punctuation.semi.sway
+#                       ^ source.sway
+#                        ^ source.sway constant.numeric.decimal.sway
+#                         ^ source.sway punctuation.brackets.square.sway
+#                          ^ source.sway punctuation.comma.sway
 >    mass: u64,
-#^^^^^^^^^^ source.sway
-#          ^^^ source.sway support.type.primitive.sway
-#             ^^ source.sway
+#^^^^ source.sway
+#    ^^^^ source.sway variable.other.sway
+#        ^ source.sway keyword.operator.key-value.sway
+#         ^ source.sway
+#          ^^^ source.sway entity.name.type.numeric.sway
+#             ^ source.sway punctuation.comma.sway
 >}
-#^^ source.sway
+#^ source.sway punctuation.brackets.curly.sway
 >
 >impl Particle {
-#^^^^ source.sway storage.type.sway
+#^^^^ source.sway keyword.other.sway
 #    ^ source.sway
 #     ^^^^^^^^ source.sway entity.name.type.sway
 #             ^ source.sway
-#              ^ source.sway
+#              ^ source.sway punctuation.brackets.curly.sway
 >    /// Creates a new Particle with the given position, velocity, acceleration, and mass
-#^^^^ source.sway
-#    ^^^ source.sway comment.line.documentation.sway
-#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sway comment.line.documentation.sway
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sway comment.line.documentation.sway
 >    fn new(position: [u64; 3], velocity: [u64; 3], acceleration: [u64; 3], mass: u64) -> Particle {
 #^^^^ source.sway
-#    ^^ source.sway keyword.other.fn.sway
-#      ^ source.sway
-#       ^^^ source.sway entity.name.function.sway
-#          ^^^^^^^^^^^^ source.sway
-#                      ^^^ source.sway support.type.primitive.sway
-#                         ^ source.sway
+#    ^^ source.sway meta.function.definition.sway keyword.other.fn.sway
+#      ^ source.sway meta.function.definition.sway
+#       ^^^ source.sway meta.function.definition.sway entity.name.function.sway
+#          ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#           ^^^^^^^^ source.sway meta.function.definition.sway variable.other.sway
+#                   ^ source.sway meta.function.definition.sway keyword.operator.key-value.sway
+#                    ^ source.sway meta.function.definition.sway
+#                     ^ source.sway meta.function.definition.sway punctuation.brackets.square.sway
+#                      ^^^ source.sway meta.function.definition.sway entity.name.type.numeric.sway
+#                         ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
 #                          ^ source.sway
-#                           ^ source.sway constant.numeric.integer.sway
-#                            ^^^^^^^^^^^^^^ source.sway
-#                                          ^^^ source.sway support.type.primitive.sway
-#                                             ^^ source.sway
-#                                               ^ source.sway constant.numeric.integer.sway
-#                                                ^^^^^^^^^^^^^^^^^^ source.sway
-#                                                                  ^^^ source.sway support.type.primitive.sway
-#                                                                     ^^ source.sway
-#                                                                       ^ source.sway constant.numeric.integer.sway
-#                                                                        ^^^^^^^^^ source.sway
-#                                                                                 ^^^ source.sway support.type.primitive.sway
-#                                                                                    ^^ source.sway
-#                                                                                      ^ source.sway keyword.operator.arithmetic.sway
-#                                                                                       ^ source.sway keyword.operator.comparison.sway
-#                                                                                        ^^^^^^^^^^^^ source.sway
+#                           ^ source.sway constant.numeric.decimal.sway
+#                            ^ source.sway punctuation.brackets.square.sway
+#                             ^ source.sway punctuation.comma.sway
+#                              ^ source.sway
+#                               ^^^^^^^^ source.sway variable.other.sway
+#                                       ^ source.sway keyword.operator.key-value.sway
+#                                        ^ source.sway
+#                                         ^ source.sway punctuation.brackets.square.sway
+#                                          ^^^ source.sway entity.name.type.numeric.sway
+#                                             ^ source.sway punctuation.semi.sway
+#                                              ^ source.sway
+#                                               ^ source.sway constant.numeric.decimal.sway
+#                                                ^ source.sway punctuation.brackets.square.sway
+#                                                 ^ source.sway punctuation.comma.sway
+#                                                  ^ source.sway
+#                                                   ^^^^^^^^^^^^ source.sway variable.other.sway
+#                                                               ^ source.sway keyword.operator.key-value.sway
+#                                                                ^ source.sway
+#                                                                 ^ source.sway punctuation.brackets.square.sway
+#                                                                  ^^^ source.sway entity.name.type.numeric.sway
+#                                                                     ^ source.sway punctuation.semi.sway
+#                                                                      ^ source.sway
+#                                                                       ^ source.sway constant.numeric.decimal.sway
+#                                                                        ^ source.sway punctuation.brackets.square.sway
+#                                                                         ^ source.sway punctuation.comma.sway
+#                                                                          ^ source.sway
+#                                                                           ^^^^ source.sway variable.other.sway
+#                                                                               ^ source.sway keyword.operator.key-value.sway
+#                                                                                ^ source.sway
+#                                                                                 ^^^ source.sway entity.name.type.numeric.sway
+#                                                                                    ^ source.sway punctuation.brackets.round.sway
+#                                                                                     ^ source.sway
+#                                                                                      ^^ source.sway keyword.operator.arrow.skinny.sway
+#                                                                                        ^ source.sway
+#                                                                                         ^^^^^^^^ source.sway entity.name.type.sway
+#                                                                                                 ^ source.sway
+#                                                                                                  ^ source.sway punctuation.brackets.curly.sway
 >        Particle {
-#^^^^^^^^^^^^^^^^^^^ source.sway
+#^^^^^^^^ source.sway
+#        ^^^^^^^^ source.sway entity.name.type.sway
+#                ^ source.sway
+#                 ^ source.sway punctuation.brackets.curly.sway
 >            position: position,
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sway
+#^^^^^^^^^^^^ source.sway
+#            ^^^^^^^^ source.sway variable.other.sway
+#                    ^ source.sway keyword.operator.key-value.sway
+#                     ^ source.sway
+#                      ^^^^^^^^ source.sway variable.other.sway
+#                              ^ source.sway punctuation.comma.sway
 >            velocity: velocity,
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sway
+#^^^^^^^^^^^^ source.sway
+#            ^^^^^^^^ source.sway variable.other.sway
+#                    ^ source.sway keyword.operator.key-value.sway
+#                     ^ source.sway
+#                      ^^^^^^^^ source.sway variable.other.sway
+#                              ^ source.sway punctuation.comma.sway
 >            acceleration: acceleration,
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sway
+#^^^^^^^^^^^^ source.sway
+#            ^^^^^^^^^^^^ source.sway variable.other.sway
+#                        ^ source.sway keyword.operator.key-value.sway
+#                         ^ source.sway
+#                          ^^^^^^^^^^^^ source.sway variable.other.sway
+#                                      ^ source.sway punctuation.comma.sway
 >            mass: mass,
-#^^^^^^^^^^^^^^^^^^^^^^^^ source.sway
+#^^^^^^^^^^^^ source.sway
+#            ^^^^ source.sway variable.other.sway
+#                ^ source.sway keyword.operator.key-value.sway
+#                 ^ source.sway
+#                  ^^^^ source.sway variable.other.sway
+#                      ^ source.sway punctuation.comma.sway
 >        }
-#^^^^^^^^^^ source.sway
+#^^^^^^^^ source.sway
+#        ^ source.sway punctuation.brackets.curly.sway
 >    }
-#^^^^^^ source.sway
+#^^^^ source.sway
+#    ^ source.sway punctuation.brackets.curly.sway
 >}
-#^^ source.sway
+#^ source.sway punctuation.brackets.curly.sway
 >
 >fn main() {
-#^^ source.sway keyword.other.fn.sway
-#  ^ source.sway
-#   ^^^^ source.sway entity.name.function.sway
-#       ^^^ source.sway
-#          ^ source.sway
+#^^ source.sway meta.function.definition.sway keyword.other.fn.sway
+#  ^ source.sway meta.function.definition.sway
+#   ^^^^ source.sway meta.function.definition.sway entity.name.function.sway
+#       ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#        ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#         ^ source.sway meta.function.definition.sway
+#          ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
 >    let position = [0, 0, 0];
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway
-#       ^^^^^^^^^^ source.sway
-#                 ^ source.sway keyword.operator.assignment.sway
-#                  ^^ source.sway
-#                    ^ source.sway constant.numeric.integer.sway
-#                     ^^ source.sway
-#                       ^ source.sway constant.numeric.integer.sway
-#                        ^^ source.sway
-#                          ^ source.sway constant.numeric.integer.sway
-#                           ^^^ source.sway
+#    ^^^ source.sway keyword.other.sway storage.type.sway
+#       ^ source.sway
+#        ^^^^^^^^ source.sway variable.other.sway
+#                ^ source.sway
+#                 ^ source.sway keyword.operator.assignment.equal.sway
+#                  ^ source.sway
+#                   ^ source.sway punctuation.brackets.square.sway
+#                    ^ source.sway constant.numeric.decimal.sway
+#                     ^ source.sway punctuation.comma.sway
+#                      ^ source.sway
+#                       ^ source.sway constant.numeric.decimal.sway
+#                        ^ source.sway punctuation.comma.sway
+#                         ^ source.sway
+#                          ^ source.sway constant.numeric.decimal.sway
+#                           ^ source.sway punctuation.brackets.square.sway
+#                            ^ source.sway punctuation.semi.sway
 >    let velocity = [0, 1, 0];
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway
-#       ^^^^^^^^^^ source.sway
-#                 ^ source.sway keyword.operator.assignment.sway
-#                  ^^ source.sway
-#                    ^ source.sway constant.numeric.integer.sway
-#                     ^^ source.sway
-#                       ^ source.sway constant.numeric.integer.sway
-#                        ^^ source.sway
-#                          ^ source.sway constant.numeric.integer.sway
-#                           ^^^ source.sway
+#    ^^^ source.sway keyword.other.sway storage.type.sway
+#       ^ source.sway
+#        ^^^^^^^^ source.sway variable.other.sway
+#                ^ source.sway
+#                 ^ source.sway keyword.operator.assignment.equal.sway
+#                  ^ source.sway
+#                   ^ source.sway punctuation.brackets.square.sway
+#                    ^ source.sway constant.numeric.decimal.sway
+#                     ^ source.sway punctuation.comma.sway
+#                      ^ source.sway
+#                       ^ source.sway constant.numeric.decimal.sway
+#                        ^ source.sway punctuation.comma.sway
+#                         ^ source.sway
+#                          ^ source.sway constant.numeric.decimal.sway
+#                           ^ source.sway punctuation.brackets.square.sway
+#                            ^ source.sway punctuation.semi.sway
 >    let acceleration = [1, 1, position[1]];
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway
-#       ^^^^^^^^^^^^^^ source.sway
-#                     ^ source.sway keyword.operator.assignment.sway
-#                      ^^ source.sway
-#                        ^ source.sway constant.numeric.integer.sway
-#                         ^^ source.sway
-#                           ^ source.sway constant.numeric.integer.sway
-#                            ^^^^^^^^^^^ source.sway
-#                                       ^ source.sway constant.numeric.integer.sway
-#                                        ^^^^ source.sway
+#    ^^^ source.sway keyword.other.sway storage.type.sway
+#       ^ source.sway
+#        ^^^^^^^^^^^^ source.sway variable.other.sway
+#                    ^ source.sway
+#                     ^ source.sway keyword.operator.assignment.equal.sway
+#                      ^ source.sway
+#                       ^ source.sway punctuation.brackets.square.sway
+#                        ^ source.sway constant.numeric.decimal.sway
+#                         ^ source.sway punctuation.comma.sway
+#                          ^ source.sway
+#                           ^ source.sway constant.numeric.decimal.sway
+#                            ^ source.sway punctuation.comma.sway
+#                             ^ source.sway
+#                              ^^^^^^^^ source.sway variable.other.sway
+#                                      ^ source.sway punctuation.brackets.square.sway
+#                                       ^ source.sway constant.numeric.decimal.sway
+#                                        ^ source.sway punctuation.brackets.square.sway
+#                                         ^ source.sway punctuation.brackets.square.sway
+#                                          ^ source.sway punctuation.semi.sway
 >    let mass = 10;
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway
-#       ^^^^^^ source.sway
-#             ^ source.sway keyword.operator.assignment.sway
+#    ^^^ source.sway keyword.other.sway storage.type.sway
+#       ^ source.sway
+#        ^^^^ source.sway variable.other.sway
+#            ^ source.sway
+#             ^ source.sway keyword.operator.assignment.equal.sway
 #              ^ source.sway
-#               ^^ source.sway constant.numeric.integer.sway
-#                 ^^ source.sway
+#               ^^ source.sway constant.numeric.decimal.sway
+#                 ^ source.sway punctuation.semi.sway
 >    let p = ~Particle::new(position, velocity, acceleration, mass);
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway
-#       ^^^ source.sway
-#          ^ source.sway keyword.operator.assignment.sway
-#           ^^^^^^^^^^ source.sway
-#                     ^^ source.sway keyword.operator.misc.sway
-#                       ^^^ source.sway entity.name.function.sway
-#                          ^ source.sway
-#                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sway
+#    ^^^ source.sway keyword.other.sway storage.type.sway
+#       ^ source.sway
+#        ^ source.sway variable.other.sway
+#         ^ source.sway
+#          ^ source.sway keyword.operator.assignment.equal.sway
+#           ^^ source.sway
+#             ^^^^^^^^ source.sway entity.name.type.sway
+#                     ^^ source.sway keyword.operator.namespace.sway
+#                       ^^^ source.sway meta.function.call.sway entity.name.function.sway
+#                          ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
+#                           ^^^^^^^^ source.sway meta.function.call.sway variable.other.sway
+#                                   ^ source.sway meta.function.call.sway punctuation.comma.sway
+#                                    ^ source.sway meta.function.call.sway
+#                                     ^^^^^^^^ source.sway meta.function.call.sway variable.other.sway
+#                                             ^ source.sway meta.function.call.sway punctuation.comma.sway
+#                                              ^ source.sway meta.function.call.sway
+#                                               ^^^^^^^^^^^^ source.sway meta.function.call.sway variable.other.sway
+#                                                           ^ source.sway meta.function.call.sway punctuation.comma.sway
+#                                                            ^ source.sway meta.function.call.sway
+#                                                             ^^^^ source.sway meta.function.call.sway variable.other.sway
+#                                                                 ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
+#                                                                  ^ source.sway punctuation.semi.sway
 >}
-#^^ source.sway
+#^ source.sway punctuation.brackets.curly.sway
 >

--- a/client/test/syntaxes/particle.sw.snap
+++ b/client/test/syntaxes/particle.sw.snap
@@ -7,7 +7,7 @@
 >pub struct Particle {
 #^^^ source.sway keyword.other.sway
 #   ^ source.sway
-#    ^^^^^^ source.sway keyword.declaration.struct.sway storage.type.sway
+#    ^^^^^^ source.sway keyword.declaration.struct.sway
 #          ^ source.sway
 #           ^^^^^^^^ source.sway entity.name.type.struct.sway
 #                   ^ source.sway
@@ -168,7 +168,7 @@
 #          ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
 >    let position = [0, 0, 0];
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway storage.type.sway
+#    ^^^ source.sway storage.modifier.sway
 #       ^ source.sway
 #        ^^^^^^^^ source.sway variable.other.sway
 #                ^ source.sway
@@ -186,7 +186,7 @@
 #                            ^ source.sway punctuation.semi.sway
 >    let velocity = [0, 1, 0];
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway storage.type.sway
+#    ^^^ source.sway storage.modifier.sway
 #       ^ source.sway
 #        ^^^^^^^^ source.sway variable.other.sway
 #                ^ source.sway
@@ -204,7 +204,7 @@
 #                            ^ source.sway punctuation.semi.sway
 >    let acceleration = [1, 1, position[1]];
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway storage.type.sway
+#    ^^^ source.sway storage.modifier.sway
 #       ^ source.sway
 #        ^^^^^^^^^^^^ source.sway variable.other.sway
 #                    ^ source.sway
@@ -225,7 +225,7 @@
 #                                          ^ source.sway punctuation.semi.sway
 >    let mass = 10;
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway storage.type.sway
+#    ^^^ source.sway storage.modifier.sway
 #       ^ source.sway
 #        ^^^^ source.sway variable.other.sway
 #            ^ source.sway
@@ -235,7 +235,7 @@
 #                 ^ source.sway punctuation.semi.sway
 >    let p = ~Particle::new(position, velocity, acceleration, mass);
 #^^^^ source.sway
-#    ^^^ source.sway keyword.other.sway storage.type.sway
+#    ^^^ source.sway storage.modifier.sway
 #       ^ source.sway
 #        ^ source.sway variable.other.sway
 #         ^ source.sway

--- a/client/test/syntaxes/particle.sw.snap
+++ b/client/test/syntaxes/particle.sw.snap
@@ -1,5 +1,5 @@
 >script;
-#^^^^^^ source.sway storage.type.sway
+#^^^^^^ source.sway source.sway meta.attribute.sway
 #      ^ source.sway
 >
 >/// A simple Particle struct

--- a/client/test/syntaxes/smo_opcode.sw
+++ b/client/test/syntaxes/smo_opcode.sw
@@ -1,0 +1,10 @@
+script;
+
+use std::constants::ZERO_B256;
+
+fn main() -> bool {
+    asm(recipient: ZERO_B256, msg_len: 0, output: 0, coins: 0) {
+        smo recipient msg_len coins output;
+    }
+    true
+}

--- a/client/test/syntaxes/smo_opcode.sw.snap
+++ b/client/test/syntaxes/smo_opcode.sw.snap
@@ -26,33 +26,33 @@
 #                  ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
 >    asm(recipient: ZERO_B256, msg_len: 0, output: 0, coins: 0) {
 #^^^^ source.sway
-#    ^^^ source.sway meta.function.call.sway entity.name.function.sway
-#       ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
-#        ^^^^^^^^^ source.sway meta.function.call.sway variable.other.sway
-#                 ^ source.sway meta.function.call.sway keyword.operator.key-value.sway
-#                  ^ source.sway meta.function.call.sway
-#                   ^^^^^^^^^ source.sway meta.function.call.sway constant.other.caps.sway
-#                            ^ source.sway meta.function.call.sway punctuation.comma.sway
-#                             ^ source.sway meta.function.call.sway
-#                              ^^^^^^^ source.sway meta.function.call.sway variable.other.sway
-#                                     ^ source.sway meta.function.call.sway keyword.operator.key-value.sway
-#                                      ^ source.sway meta.function.call.sway
-#                                       ^ source.sway meta.function.call.sway constant.numeric.decimal.sway
-#                                        ^ source.sway meta.function.call.sway punctuation.comma.sway
-#                                         ^ source.sway meta.function.call.sway
-#                                          ^^^^^^ source.sway meta.function.call.sway variable.other.sway
-#                                                ^ source.sway meta.function.call.sway keyword.operator.key-value.sway
-#                                                 ^ source.sway meta.function.call.sway
-#                                                  ^ source.sway meta.function.call.sway constant.numeric.decimal.sway
-#                                                   ^ source.sway meta.function.call.sway punctuation.comma.sway
-#                                                    ^ source.sway meta.function.call.sway
-#                                                     ^^^^^ source.sway meta.function.call.sway variable.other.sway
-#                                                          ^ source.sway meta.function.call.sway keyword.operator.key-value.sway
-#                                                           ^ source.sway meta.function.call.sway
-#                                                            ^ source.sway meta.function.call.sway constant.numeric.decimal.sway
-#                                                             ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
-#                                                              ^ source.sway
-#                                                               ^ source.sway punctuation.brackets.curly.sway
+#    ^^^ source.sway meta.asm.definition.sway meta.attribute.asm.sway
+#       ^ source.sway meta.asm.definition.sway punctuation.brackets.round.sway
+#        ^^^^^^^^^ source.sway meta.asm.definition.sway variable.other.sway
+#                 ^ source.sway meta.asm.definition.sway keyword.operator.key-value.sway
+#                  ^ source.sway meta.asm.definition.sway
+#                   ^^^^^^^^^ source.sway meta.asm.definition.sway constant.other.caps.sway
+#                            ^ source.sway meta.asm.definition.sway punctuation.comma.sway
+#                             ^ source.sway meta.asm.definition.sway
+#                              ^^^^^^^ source.sway meta.asm.definition.sway variable.other.sway
+#                                     ^ source.sway meta.asm.definition.sway keyword.operator.key-value.sway
+#                                      ^ source.sway meta.asm.definition.sway
+#                                       ^ source.sway meta.asm.definition.sway constant.numeric.decimal.sway
+#                                        ^ source.sway meta.asm.definition.sway punctuation.comma.sway
+#                                         ^ source.sway meta.asm.definition.sway
+#                                          ^^^^^^ source.sway meta.asm.definition.sway variable.other.sway
+#                                                ^ source.sway meta.asm.definition.sway keyword.operator.key-value.sway
+#                                                 ^ source.sway meta.asm.definition.sway
+#                                                  ^ source.sway meta.asm.definition.sway constant.numeric.decimal.sway
+#                                                   ^ source.sway meta.asm.definition.sway punctuation.comma.sway
+#                                                    ^ source.sway meta.asm.definition.sway
+#                                                     ^^^^^ source.sway meta.asm.definition.sway variable.other.sway
+#                                                          ^ source.sway meta.asm.definition.sway keyword.operator.key-value.sway
+#                                                           ^ source.sway meta.asm.definition.sway
+#                                                            ^ source.sway meta.asm.definition.sway constant.numeric.decimal.sway
+#                                                             ^ source.sway meta.asm.definition.sway punctuation.brackets.round.sway
+#                                                              ^ source.sway meta.asm.definition.sway
+#                                                               ^ source.sway meta.asm.definition.sway punctuation.brackets.curly.sway
 >        smo recipient msg_len coins output;
 #^^^^^^^^ source.sway
 #        ^^^ source.sway variable.other.sway

--- a/client/test/syntaxes/smo_opcode.sw.snap
+++ b/client/test/syntaxes/smo_opcode.sw.snap
@@ -1,0 +1,76 @@
+>script;
+#^^^^^^ source.sway source.sway meta.attribute.sway
+#      ^ source.sway
+>
+>use std::constants::ZERO_B256;
+#^^^ source.sway meta.use.sway keyword.other.sway
+#   ^ source.sway meta.use.sway
+#    ^^^ source.sway meta.use.sway entity.name.namespace.sway
+#       ^^ source.sway meta.use.sway keyword.operator.namespace.sway
+#         ^^^^^^^^^ source.sway meta.use.sway entity.name.namespace.sway
+#                  ^^ source.sway meta.use.sway keyword.operator.namespace.sway
+#                    ^^^^^^^^^ source.sway meta.use.sway
+#                             ^ source.sway meta.use.sway punctuation.semi.sway
+>
+>fn main() -> bool {
+#^^ source.sway meta.function.definition.sway keyword.other.fn.sway
+#  ^ source.sway meta.function.definition.sway
+#   ^^^^ source.sway meta.function.definition.sway entity.name.function.sway
+#       ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#        ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#         ^ source.sway meta.function.definition.sway
+#          ^^ source.sway meta.function.definition.sway keyword.operator.arrow.skinny.sway
+#            ^ source.sway meta.function.definition.sway
+#             ^^^^ source.sway meta.function.definition.sway entity.name.type.primitive.sway
+#                 ^ source.sway meta.function.definition.sway
+#                  ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
+>    asm(recipient: ZERO_B256, msg_len: 0, output: 0, coins: 0) {
+#^^^^ source.sway
+#    ^^^ source.sway meta.function.call.sway entity.name.function.sway
+#       ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
+#        ^^^^^^^^^ source.sway meta.function.call.sway variable.other.sway
+#                 ^ source.sway meta.function.call.sway keyword.operator.key-value.sway
+#                  ^ source.sway meta.function.call.sway
+#                   ^^^^^^^^^ source.sway meta.function.call.sway constant.other.caps.sway
+#                            ^ source.sway meta.function.call.sway punctuation.comma.sway
+#                             ^ source.sway meta.function.call.sway
+#                              ^^^^^^^ source.sway meta.function.call.sway variable.other.sway
+#                                     ^ source.sway meta.function.call.sway keyword.operator.key-value.sway
+#                                      ^ source.sway meta.function.call.sway
+#                                       ^ source.sway meta.function.call.sway constant.numeric.decimal.sway
+#                                        ^ source.sway meta.function.call.sway punctuation.comma.sway
+#                                         ^ source.sway meta.function.call.sway
+#                                          ^^^^^^ source.sway meta.function.call.sway variable.other.sway
+#                                                ^ source.sway meta.function.call.sway keyword.operator.key-value.sway
+#                                                 ^ source.sway meta.function.call.sway
+#                                                  ^ source.sway meta.function.call.sway constant.numeric.decimal.sway
+#                                                   ^ source.sway meta.function.call.sway punctuation.comma.sway
+#                                                    ^ source.sway meta.function.call.sway
+#                                                     ^^^^^ source.sway meta.function.call.sway variable.other.sway
+#                                                          ^ source.sway meta.function.call.sway keyword.operator.key-value.sway
+#                                                           ^ source.sway meta.function.call.sway
+#                                                            ^ source.sway meta.function.call.sway constant.numeric.decimal.sway
+#                                                             ^ source.sway meta.function.call.sway punctuation.brackets.round.sway
+#                                                              ^ source.sway
+#                                                               ^ source.sway punctuation.brackets.curly.sway
+>        smo recipient msg_len coins output;
+#^^^^^^^^ source.sway
+#        ^^^ source.sway variable.other.sway
+#           ^ source.sway
+#            ^^^^^^^^^ source.sway variable.other.sway
+#                     ^ source.sway
+#                      ^^^^^^^ source.sway variable.other.sway
+#                             ^ source.sway
+#                              ^^^^^ source.sway variable.other.sway
+#                                   ^ source.sway
+#                                    ^^^^^^ source.sway variable.other.sway
+#                                          ^ source.sway punctuation.semi.sway
+>    }
+#^^^^ source.sway
+#    ^ source.sway punctuation.brackets.curly.sway
+>    true
+#^^^^ source.sway
+#    ^^^^ source.sway constant.language.bool.sway
+>}
+#^ source.sway punctuation.brackets.curly.sway
+>

--- a/client/test/syntaxes/storage_declaration.sw
+++ b/client/test/syntaxes/storage_declaration.sw
@@ -1,0 +1,8 @@
+contract;
+storage {
+    supply: u64 = 0,
+    demand: u64 = 0,
+    name: str[4] = "test",
+}
+fn main() {
+}

--- a/client/test/syntaxes/storage_declaration.sw.snap
+++ b/client/test/syntaxes/storage_declaration.sw.snap
@@ -1,5 +1,5 @@
 >contract;
-#^^^^^^^^ source.sway storage.type.sway
+#^^^^^^^^ source.sway source.sway meta.attribute.sway
 #        ^ source.sway
 >storage {
 #^^^^^^^ source.sway variable.other.sway

--- a/client/test/syntaxes/storage_declaration.sw.snap
+++ b/client/test/syntaxes/storage_declaration.sw.snap
@@ -1,0 +1,58 @@
+>contract;
+#^^^^^^^^ source.sway storage.type.sway
+#        ^ source.sway
+>storage {
+#^^^^^^^ source.sway variable.other.sway
+#       ^ source.sway
+#        ^ source.sway punctuation.brackets.curly.sway
+>    supply: u64 = 0,
+#^^^^ source.sway
+#    ^^^^^^ source.sway variable.other.sway
+#          ^ source.sway keyword.operator.key-value.sway
+#           ^ source.sway
+#            ^^^ source.sway entity.name.type.numeric.sway
+#               ^ source.sway
+#                ^ source.sway keyword.operator.assignment.equal.sway
+#                 ^ source.sway
+#                  ^ source.sway constant.numeric.decimal.sway
+#                   ^ source.sway punctuation.comma.sway
+>    demand: u64 = 0,
+#^^^^ source.sway
+#    ^^^^^^ source.sway variable.other.sway
+#          ^ source.sway keyword.operator.key-value.sway
+#           ^ source.sway
+#            ^^^ source.sway entity.name.type.numeric.sway
+#               ^ source.sway
+#                ^ source.sway keyword.operator.assignment.equal.sway
+#                 ^ source.sway
+#                  ^ source.sway constant.numeric.decimal.sway
+#                   ^ source.sway punctuation.comma.sway
+>    name: str[4] = "test",
+#^^^^ source.sway
+#    ^^^^ source.sway variable.other.sway
+#        ^ source.sway keyword.operator.key-value.sway
+#         ^ source.sway
+#          ^^^ source.sway entity.name.type.primitive.sway
+#             ^ source.sway punctuation.brackets.square.sway
+#              ^ source.sway constant.numeric.decimal.sway
+#               ^ source.sway punctuation.brackets.square.sway
+#                ^ source.sway
+#                 ^ source.sway keyword.operator.assignment.equal.sway
+#                  ^ source.sway
+#                   ^ source.sway string.quoted.double.sway punctuation.definition.string.sway
+#                    ^^^^ source.sway string.quoted.double.sway
+#                        ^ source.sway string.quoted.double.sway punctuation.definition.string.sway
+#                         ^ source.sway punctuation.comma.sway
+>}
+#^ source.sway punctuation.brackets.curly.sway
+>fn main() {
+#^^ source.sway meta.function.definition.sway keyword.other.fn.sway
+#  ^ source.sway meta.function.definition.sway
+#   ^^^^ source.sway meta.function.definition.sway entity.name.function.sway
+#       ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#        ^ source.sway meta.function.definition.sway punctuation.brackets.round.sway
+#         ^ source.sway meta.function.definition.sway
+#          ^ source.sway meta.function.definition.sway punctuation.brackets.curly.sway
+>}
+#^ source.sway punctuation.brackets.curly.sway
+>

--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -163,14 +163,14 @@
       ]
     },
     {
-      "comment": "modules",
-      "match": "(mod)\\s+((?:r#(?!crate|[Ss]elf|super))?[a-z][A-Za-z0-9_]*)",
+      "comment": "dependency",
+      "match": "(dep)\\s+((?:r#(?!crate|[Ss]elf|super))?[a-z][A-Za-z0-9_]*)",
       "captures": {
         "1": {
           "name": "storage.type.sway"
         },
         "2": {
-          "name": "entity.name.module.sway"
+          "name": "entity.name.dependency.sway"
         }
       }
     },
@@ -653,7 +653,7 @@
         {
           "comment": "storage keywords",
           "name": "keyword.other.sway storage.type.sway",
-          "match": "\\b(extern|macro|mod)\\b"
+          "match": "\\b(extern|macro|dep)\\b"
         },
         {
           "comment": "const keyword",

--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -1,439 +1,1167 @@
 {
-  "name": "sway",
+  "name": "Sway",
+  "fileTypes": [
+      "sw"
+  ],
   "scopeName": "source.sway",
   "patterns": [
-    {
-      "comment": "Implementation",
-      "begin": "\\b(impl)\\b",
-      "end": "\\{",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.sway"
-        }
+      {
+          "comment": "boxed slice literal",
+          "begin": "(<)(\\[)",
+          "beginCaptures": {
+              "1": {
+                  "name": "punctuation.brackets.angle.sway"
+              },
+              "2": {
+                  "name": "punctuation.brackets.square.sway"
+              }
+          },
+          "end": ">",
+          "endCaptures": {
+              "0": {
+                  "name": "punctuation.brackets.angle.sway"
+              }
+          },
+          "patterns": [
+              {
+                  "include": "#block-comments"
+              },
+              {
+                  "include": "#comments"
+              },
+              {
+                  "include": "#gtypes"
+              },
+              {
+                  "include": "#lvariables"
+              },
+              {
+                  "include": "#lifetimes"
+              },
+              {
+                  "include": "#punctuation"
+              },
+              {
+                  "include": "#types"
+              }
+          ]
       },
-      "patterns": [
-        {
-          "include": "#block_comment"
-        },
-        {
-          "include": "#line_comment"
-        },
-        {
-          "include": "#sigils"
-        },
-        {
-          "include": "#mut"
-        },
-        {
-          "include": "#core_types"
-        },
-        {
-          "include": "#type_params"
-        },
-        {
-          "include": "#where"
-        },
-        {
-          "name": "storage.type.sway",
-          "match": "\\bfor\\b"
-        },
-        {
-          "include": "#type"
-        }
-      ]
-    },
-    {
-      "include": "#block_doc_comment"
-    },
-    {
-      "include": "#block_comment"
-    },
-    {
-      "include": "#line_doc_comment"
-    },
-    {
-      "include": "#line_comment"
-    },
-    {
-      "comment": "Integer literal (decimal)",
-      "name": "constant.numeric.integer.sway",
-      "match": "\\b[0-9][0-9_]*([u](8|16|32|64|128))?\\b"
-    },
-    {
-      "comment": "Integer literal (hexadecimal)",
-      "name": "constant.numeric.integer.hexadecimal.sway",
-      "match": "\\b0x[a-fA-F0-9_]+([u](8|16|32|64|128))?\\b"
-    },
-    {
-      "comment": "Integer literal (binary)",
-      "name": "constant.numeric.integer.binary.sway",
-      "match": "\\b0b[01_]+([u](8|16|32|64|128))?\\b"
-    },
-    {
-      "comment": "Boolean constant",
-      "name": "constant.language.boolean.sway",
-      "match": "\\b(true|false)\\b"
-    },
-    {
-      "comment": "Control keyword",
-      "name": "keyword.control.sway",
-      "match": "\\b(else|if|for|match|return|while)\\b"
-    },
-    {
-      "comment": "Keyword",
-      "name": "keyword.other.sway",
-      "match": "\\b(break|continue|deref|enum|struct|let|ref|use|asm|dep)\\b"
-    },
-    {
-      "include": "#sigils"
-    },
-    {
-      "include": "#self"
-    },
-    {
-      "include": "#string_literal"
-    },
-    {
-      "include": "#mut"
-    },
-    {
-      "include": "#impl"
-    },
-    {
-      "include": "#pub"
-    },
-    {
-      "comment": "Miscellaneous operator",
-      "name": "keyword.operator.misc.sway",
-      "match": "(=>|::|->\\?)"
-    },
-    {
-      "comment": "Comparison operator",
-      "name": "keyword.operator.comparison.sway",
-      "match": "(&&|\\|\\||==|!=)"
-    },
-    {
-      "comment": "Assignment operator",
-      "name": "keyword.operator.assignment.sway",
-      "match": "(\\+=|-=|/=|\\*=|%=|\\^=|&=|\\|=|<<=|>>=|=)"
-    },
-    {
-      "comment": "Arithmetic operator",
-      "name": "keyword.operator.arithmetic.sway",
-      "match": "(!|\\+|-|/|\\*|%|\\^|&|\\||<<|>>)"
-    },
-    {
-      "comment": "Comparison operator (second group because of regex precedence)",
-      "name": "keyword.operator.comparison.sway",
-      "match": "(<=|>=|<|>)"
-    },
-    {
-      "include": "#core_types"
-    },
-    {
-      "comment": "Function call",
-      "match": "\\b([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)\\s*\\(",
-      "captures": {
-        "1": {
-          "name": "entity.name.function.sway"
-        }
+      {
+          "comment": "macro type metavariables",
+          "name": "meta.macro.metavariable.type.sway",
+          "match": "(\\$)((crate)|([A-Z][A-Za-z0-9_]*))((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?",
+          "captures": {
+              "1": {
+                  "name": "keyword.operator.macro.dollar.sway"
+              },
+              "3": {
+                  "name": "keyword.other.crate.sway"
+              },
+              "4": {
+                  "name": "entity.name.type.metavariable.sway"
+              },
+              "6": {
+                  "name": "keyword.operator.key-value.sway"
+              },
+              "7": {
+                  "name": "variable.other.metavariable.specifier.sway"
+              }
+          },
+          "patterns": [
+              {
+                  "include": "#keywords"
+              }
+          ]
+      },
+      {
+          "comment": "macro metavariables",
+          "name": "meta.macro.metavariable.sway",
+          "match": "(\\$)([a-z][A-Za-z0-9_]*)((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?",
+          "captures": {
+              "1": {
+                  "name": "keyword.operator.macro.dollar.sway"
+              },
+              "2": {
+                  "name": "variable.other.metavariable.name.sway"
+              },
+              "4": {
+                  "name": "keyword.operator.key-value.sway"
+              },
+              "5": {
+                  "name": "variable.other.metavariable.specifier.sway"
+              }
+          },
+          "patterns": [
+              {
+                  "include": "#keywords"
+              }
+          ]
+      },
+      {
+          "comment": "macro rules",
+          "name": "meta.macro.rules.sway",
+          "match": "\\b(macro_rules!)\\s+(([a-z0-9_]+)|([A-Z][a-z0-9_]*))\\s+(\\{)",
+          "captures": {
+              "1": {
+                  "name": "entity.name.function.macro.rules.sway"
+              },
+              "3": {
+                  "name": "entity.name.function.macro.sway"
+              },
+              "4": {
+                  "name": "entity.name.type.macro.sway"
+              },
+              "5": {
+                  "name": "punctuation.brackets.curly.sway"
+              }
+          }
+      },
+      {
+          "comment": "attributes",
+          "name": "meta.attribute.sway",
+          "begin": "(#)(\\!?)(\\[)",
+          "beginCaptures": {
+              "1": {
+                  "name": "punctuation.definition.attribute.sway"
+              },
+              "2": {
+                  "name": "keyword.operator.attribute.inner.sway"
+              },
+              "3": {
+                  "name": "punctuation.brackets.attribute.sway"
+              }
+          },
+          "end": "\\]",
+          "endCaptures": {
+              "0": {
+                  "name": "punctuation.brackets.attribute.sway"
+              }
+          },
+          "patterns": [
+              {
+                  "include": "#block-comments"
+              },
+              {
+                  "include": "#comments"
+              },
+              {
+                  "include": "#keywords"
+              },
+              {
+                  "include": "#lifetimes"
+              },
+              {
+                  "include": "#punctuation"
+              },
+              {
+                  "include": "#strings"
+              },
+              {
+                  "include": "#gtypes"
+              },
+              {
+                  "include": "#types"
+              }
+          ]
+      },
+      {
+          "comment": "modules",
+          "match": "(mod)\\s+((?:r#(?!crate|[Ss]elf|super))?[a-z][A-Za-z0-9_]*)",
+          "captures": {
+              "1": {
+                  "name": "storage.type.sway"
+              },
+              "2": {
+                  "name": "entity.name.module.sway"
+              }
+          }
+      },
+      {
+          "comment": "external crate imports",
+          "name": "meta.import.sway",
+          "begin": "\\b(extern)\\s+(crate)",
+          "beginCaptures": {
+              "1": {
+                  "name": "storage.type.sway"
+              },
+              "2": {
+                  "name": "keyword.other.crate.sway"
+              }
+          },
+          "end": ";",
+          "endCaptures": {
+              "0": {
+                  "name": "punctuation.semi.sway"
+              }
+          },
+          "patterns": [
+              {
+                  "include": "#block-comments"
+              },
+              {
+                  "include": "#comments"
+              },
+              {
+                  "include": "#keywords"
+              },
+              {
+                  "include": "#punctuation"
+              }
+          ]
+      },
+      {
+          "comment": "use statements",
+          "name": "meta.use.sway",
+          "begin": "\\b(use)\\s",
+          "beginCaptures": {
+              "1": {
+                  "name": "keyword.other.sway"
+              }
+          },
+          "end": ";",
+          "endCaptures": {
+              "0": {
+                  "name": "punctuation.semi.sway"
+              }
+          },
+          "patterns": [
+              {
+                  "include": "#block-comments"
+              },
+              {
+                  "include": "#comments"
+              },
+              {
+                  "include": "#keywords"
+              },
+              {
+                  "include": "#namespaces"
+              },
+              {
+                  "include": "#punctuation"
+              },
+              {
+                  "include": "#types"
+              },
+              {
+                  "include": "#lvariables"
+              }
+          ]
+      },
+      {
+          "include": "#block-comments"
+      },
+      {
+          "include": "#comments"
+      },
+      {
+          "include": "#lvariables"
+      },
+      {
+          "include": "#constants"
+      },
+      {
+          "include": "#gtypes"
+      },
+      {
+          "include": "#functions"
+      },
+      {
+          "include": "#types"
+      },
+      {
+          "include": "#keywords"
+      },
+      {
+          "include": "#lifetimes"
+      },
+      {
+          "include": "#macros"
+      },
+      {
+          "include": "#namespaces"
+      },
+      {
+          "include": "#punctuation"
+      },
+      {
+          "include": "#strings"
+      },
+      {
+          "include": "#variables"
       }
-    },
-    {
-      "comment": "Function call with type parameters",
-      "begin": "\\b([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)\\s*(::)(?=\\s*<.*>\\s*\\()",
-      "end": "\\(",
-      "captures": {
-        "1": {
-          "name": "entity.name.function.sway"
-        },
-        "2": {
-          "name": "keyword.operator.misc.sway"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#type_params"
-        }
-      ]
-    },
-    {
-      "comment": "Function definition",
-      "begin": "\\b(fn)\\s+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)",
-      "end": "[\\{;]",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.other.fn.sway"
-        },
-        "2": {
-          "name": "entity.name.function.sway"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#block_comment"
-        },
-        {
-          "include": "#line_comment"
-        },
-        {
-          "include": "#sigils"
-        },
-        {
-          "include": "#self"
-        },
-        {
-          "include": "#mut"
-        },
-        {
-          "include": "#impl"
-        },
-        {
-          "include": "#core_types"
-        },
-        {
-          "include": "#type_params"
-        },
-        {
-          "include": "#where"
-        },
-        {
-          "comment": "Function arguments",
-          "match": "\bfn\b",
-          "name": "keyword.other.fn.sway"
-        }
-      ]
-    },
-    {
-      "comment": "Top level declaration",
-      "begin": "\\b(library)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-      "end": "[\\{\\(;]",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.sway"
-        },
-        "2": {
-          "name": "entity.name.type.sway"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#block_comment"
-        },
-        {
-          "include": "#line_comment"
-        },
-        {
-          "include": "#impl"
-        },
-        {
-          "include": "#type_params"
-        },
-        {
-          "include": "#core_types"
-        },
-        {
-          "include": "#pub"
-        },
-        {
-          "include": "#where"
-        }
-      ]
-    },
-    {
-      "comment": "Top level declaration without name",
-      "match": "(contract|script|predicate);",
-      "captures": {
-        "1": {
-          "name": "storage.type.sway"
-        }
-      }
-    },
-    {
-      "comment": "Type declaration without name",
-      "begin": "\\b(storage)",
-      "end": "[\\{\\(;]",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.sway"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#block_comment"
-        },
-        {
-          "include": "#line_comment"
-        },
-        {
-          "include": "#type_params"
-        },
-        {
-          "include": "#core_types"
-        },
-        {
-          "include": "#pub"
-        }
-      ]
-    },
-    {
-      "comment": "Type declaration",
-      "begin": "\\b(enum|struct|trait|abi)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-      "end": "[\\{\\(;]",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.sway"
-        },
-        "2": {
-          "name": "entity.name.type.sway"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#block_comment"
-        },
-        {
-          "include": "#line_comment"
-        },
-        {
-          "include": "#type_params"
-        },
-        {
-          "include": "#core_types"
-        },
-        {
-          "include": "#pub"
-        },
-        {
-          "include": "#where"
-        }
-      ]
-    }
   ],
   "repository": {
-    "block_doc_comment": {
-      "comment": "Block documentation comment",
-      "name": "comment.block.documentation.sway",
-      "begin": "/\\*[\\*!](?![\\*/])",
-      "end": "\\*/",
-      "patterns": [
-        {
-          "include": "#block_doc_comment"
-        },
-        {
-          "include": "#block_comment"
-        }
-      ]
-    },
-    "block_comment": {
-      "comment": "Block comment",
-      "name": "comment.block.sway",
-      "begin": "/\\*",
-      "end": "\\*/",
-      "patterns": [
-        {
-          "include": "#block_doc_comment"
-        },
-        {
-          "include": "#block_comment"
-        }
-      ]
-    },
-    "line_doc_comment": {
-      "comment": "Single-line documentation comment",
-      "name": "comment.line.documentation.sway",
-      "begin": "//[!/](?=[^/])",
-      "end": "$"
-    },
-    "line_comment": {
-      "comment": "Single-line comment",
-      "name": "comment.line.double-slash.sway",
-      "begin": "//",
-      "end": "$"
-    },
-    "escaped_character": {
-      "name": "constant.character.escape.sway",
-      "match": "\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)"
-    },
-    "string_literal": {
-      "comment": "Double-quote string literal",
-      "name": "string.quoted.double.sway",
-      "begin": "\"",
-      "end": "\"",
-      "patterns": [
-        {
-          "include": "#escaped_character"
-        }
-      ]
-    },
-    "sigils": {
-      "comment": "Sigil",
-      "name": "keyword.operator.sigil.sway",
-      "match": "[&*](?=[a-zA-Z0-9_\\(\\[\\|\\\"]+)"
-    },
-    "self": {
-      "comment": "Self variable",
-      "name": "variable.language.sway",
-      "match": "\\bself\\b"
-    },
-    "mut": {
-      "comment": "Mutable storage modifier",
-      "name": "storage.modifier.mut.sway",
-      "match": "\\bmut\\b"
-    },
-    "impl": {
-      "comment": "Existential type modifier",
-      "name": "storage.modifier.impl.sway",
-      "match": "\\bimpl\\b"
-    },
-    "pub": {
-      "comment": "Visibility modifier",
-      "name": "storage.modifier.visibility.sway",
-      "match": "\\bpub\\b"
-    },
-    "where": {
-      "comment": "Generic where clause",
-      "name": "keyword.other.where.sway",
-      "match": "\\bwhere\\b"
-    },
-    "core_types": {
-      "comment": "Built-in/core type",
-      "name": "support.type.primitive.sway",
-      "match": "\\b(bool|char|u8|u16|u32|u64|string|b256|str|Self)\\b"
-    },
-    "type": {
-      "comment": "A type",
-      "name": "entity.name.type.sway",
-      "match": "\\b([A-Za-z][_A-Za-z0-9]*|_[_A-Za-z0-9]+)\\b"
-    },
-    "type_params": {
-      "comment": "Type parameters",
-      "name": "meta.type_params.sway",
-      "begin": "<(?![=<])",
-      "end": "(?<![-])>",
-      "patterns": [
-        {
-          "include": "#block_comment"
-        },
-        {
-          "include": "#line_comment"
-        },
-        {
-          "include": "#sigils"
-        },
-        {
-          "include": "#mut"
-        },
-        {
-          "include": "#impl"
-        },
-        {
-          "include": "#core_types"
-        },
-        {
-          "include": "#type_params"
-        }
-      ]
-    }
+      "comments": {
+          "patterns": [
+              {
+                  "comment": "documentation comments",
+                  "name": "comment.line.documentation.sway",
+                  "match": "^\\s*///.*"
+              },
+              {
+                  "comment": "line comments",
+                  "name": "comment.line.double-slash.sway",
+                  "match": "\\s*//.*"
+              }
+          ]
+      },
+      "block-comments": {
+          "patterns": [
+              {
+                  "comment": "empty block comments",
+                  "name": "comment.block.sway",
+                  "match": "/\\*\\*/"
+              },
+              {
+                  "comment": "block documentation comments",
+                  "name": "comment.block.documentation.sway",
+                  "begin": "/\\*\\*",
+                  "end": "\\*/",
+                  "patterns": [
+                      {
+                          "include": "#block-comments"
+                      }
+                  ]
+              },
+              {
+                  "comment": "block comments",
+                  "name": "comment.block.sway",
+                  "begin": "/\\*(?!\\*)",
+                  "end": "\\*/",
+                  "patterns": [
+                      {
+                          "include": "#block-comments"
+                      }
+                  ]
+              }
+          ]
+      },
+      "constants": {
+          "patterns": [
+              {
+                  "comment": "ALL CAPS constants",
+                  "name": "constant.other.caps.sway",
+                  "match": "\\b[A-Z]{2}[A-Z0-9_]*\\b"
+              },
+              {
+                  "comment": "constant declarations",
+                  "match": "\\b(const)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+                  "captures": {
+                      "1": {
+                          "name": "storage.type.sway"
+                      },
+                      "2": {
+                          "name": "constant.other.caps.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "decimal integers and floats",
+                  "name": "constant.numeric.decimal.sway",
+                  "match": "\\b\\d[\\d_]*(\\.?)[\\d_]*(?:(E)([+-])([\\d_]+))?(f32|f64|i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+                  "captures": {
+                      "1": {
+                          "name": "punctuation.separator.dot.decimal.sway"
+                      },
+                      "2": {
+                          "name": "keyword.operator.exponent.sway"
+                      },
+                      "3": {
+                          "name": "keyword.operator.exponent.sign.sway"
+                      },
+                      "4": {
+                          "name": "constant.numeric.decimal.exponent.mantissa.sway"
+                      },
+                      "5": {
+                          "name": "entity.name.type.numeric.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "hexadecimal integers",
+                  "name": "constant.numeric.hex.sway",
+                  "match": "\\b0x[\\da-fA-F_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+                  "captures": {
+                      "1": {
+                          "name": "entity.name.type.numeric.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "octal integers",
+                  "name": "constant.numeric.oct.sway",
+                  "match": "\\b0o[0-7_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+                  "captures": {
+                      "1": {
+                          "name": "entity.name.type.numeric.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "binary integers",
+                  "name": "constant.numeric.bin.sway",
+                  "match": "\\b0b[01_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+                  "captures": {
+                      "1": {
+                          "name": "entity.name.type.numeric.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "booleans",
+                  "name": "constant.language.bool.sway",
+                  "match": "\\b(true|false)\\b"
+              }
+          ]
+      },
+      "escapes": {
+          "comment": "escapes: ASCII, byte, Unicode, quote, regex",
+          "name": "constant.character.escape.sway",
+          "match": "(\\\\)(?:(?:(x[0-7][0-7a-fA-F])|(u(\\{)[\\da-fA-F]{4,6}(\\}))|.))",
+          "captures": {
+              "1": {
+                  "name": "constant.character.escape.backslash.sway"
+              },
+              "2": {
+                  "name": "constant.character.escape.bit.sway"
+              },
+              "3": {
+                  "name": "constant.character.escape.unicode.sway"
+              },
+              "4": {
+                  "name": "constant.character.escape.unicode.punctuation.sway"
+              },
+              "5": {
+                  "name": "constant.character.escape.unicode.punctuation.sway"
+              }
+          }
+      },
+      "functions": {
+          "patterns": [
+              {
+                  "comment": "pub as a function",
+                  "match": "\\b(pub)(\\()",
+                  "captures": {
+                      "1": {
+                          "name": "keyword.other.sway"
+                      },
+                      "2": {
+                          "name": "punctuation.brackets.round.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "function definition",
+                  "name": "meta.function.definition.sway",
+                  "begin": "\\b(fn)\\s+((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)((\\()|(<))",
+                  "beginCaptures": {
+                      "1": {
+                          "name": "keyword.other.fn.sway"
+                      },
+                      "2": {
+                          "name": "entity.name.function.sway"
+                      },
+                      "4": {
+                          "name": "punctuation.brackets.round.sway"
+                      },
+                      "5": {
+                          "name": "punctuation.brackets.angle.sway"
+                      }
+                  },
+                  "end": "\\{|;",
+                  "endCaptures": {
+                      "0": {
+                          "name": "punctuation.brackets.curly.sway"
+                      }
+                  },
+                  "patterns": [
+                      {
+                          "include": "#block-comments"
+                      },
+                      {
+                          "include": "#comments"
+                      },
+                      {
+                          "include": "#keywords"
+                      },
+                      {
+                          "include": "#lvariables"
+                      },
+                      {
+                          "include": "#constants"
+                      },
+                      {
+                          "include": "#gtypes"
+                      },
+                      {
+                          "include": "#functions"
+                      },
+                      {
+                          "include": "#lifetimes"
+                      },
+                      {
+                          "include": "#macros"
+                      },
+                      {
+                          "include": "#namespaces"
+                      },
+                      {
+                          "include": "#punctuation"
+                      },
+                      {
+                          "include": "#strings"
+                      },
+                      {
+                          "include": "#types"
+                      },
+                      {
+                          "include": "#variables"
+                      }
+                  ]
+              },
+              {
+                  "comment": "function/method calls, chaining",
+                  "name": "meta.function.call.sway",
+                  "begin": "((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)(\\()",
+                  "beginCaptures": {
+                      "1": {
+                          "name": "entity.name.function.sway"
+                      },
+                      "2": {
+                          "name": "punctuation.brackets.round.sway"
+                      }
+                  },
+                  "end": "\\)",
+                  "endCaptures": {
+                      "0": {
+                          "name": "punctuation.brackets.round.sway"
+                      }
+                  },
+                  "patterns": [
+                      {
+                          "include": "#block-comments"
+                      },
+                      {
+                          "include": "#comments"
+                      },
+                      {
+                          "include": "#keywords"
+                      },
+                      {
+                          "include": "#lvariables"
+                      },
+                      {
+                          "include": "#constants"
+                      },
+                      {
+                          "include": "#gtypes"
+                      },
+                      {
+                          "include": "#functions"
+                      },
+                      {
+                          "include": "#lifetimes"
+                      },
+                      {
+                          "include": "#macros"
+                      },
+                      {
+                          "include": "#namespaces"
+                      },
+                      {
+                          "include": "#punctuation"
+                      },
+                      {
+                          "include": "#strings"
+                      },
+                      {
+                          "include": "#types"
+                      },
+                      {
+                          "include": "#variables"
+                      }
+                  ]
+              },
+              {
+                  "comment": "function/method calls with turbofish",
+                  "name": "meta.function.call.sway",
+                  "begin": "((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)(?=::<.*>\\()",
+                  "beginCaptures": {
+                      "1": {
+                          "name": "entity.name.function.sway"
+                      }
+                  },
+                  "end": "\\)",
+                  "endCaptures": {
+                      "0": {
+                          "name": "punctuation.brackets.round.sway"
+                      }
+                  },
+                  "patterns": [
+                      {
+                          "include": "#block-comments"
+                      },
+                      {
+                          "include": "#comments"
+                      },
+                      {
+                          "include": "#keywords"
+                      },
+                      {
+                          "include": "#lvariables"
+                      },
+                      {
+                          "include": "#constants"
+                      },
+                      {
+                          "include": "#gtypes"
+                      },
+                      {
+                          "include": "#functions"
+                      },
+                      {
+                          "include": "#lifetimes"
+                      },
+                      {
+                          "include": "#macros"
+                      },
+                      {
+                          "include": "#namespaces"
+                      },
+                      {
+                          "include": "#punctuation"
+                      },
+                      {
+                          "include": "#strings"
+                      },
+                      {
+                          "include": "#types"
+                      },
+                      {
+                          "include": "#variables"
+                      }
+                  ]
+              }
+          ]
+      },
+      "keywords": {
+          "patterns": [
+              {
+                  "comment": "control flow keywords",
+                  "name": "keyword.control.sway",
+                  "match": "\\b(await|break|continue|do|else|for|if|loop|match|return|try|while|yield)\\b"
+              },
+              {
+                  "comment": "storage keywords",
+                  "name": "keyword.other.sway storage.type.sway",
+                  "match": "\\b(extern|let|macro|mod)\\b"
+              },
+              {
+                  "comment": "const keyword",
+                  "name": "storage.modifier.sway",
+                  "match": "\\b(const)\\b"
+              },
+              {
+                  "comment": "type keyword",
+                  "name": "keyword.declaration.type.sway storage.type.sway",
+                  "match": "\\b(type)\\b"
+              },
+              {
+                  "comment": "enum keyword",
+                  "name": "keyword.declaration.enum.sway storage.type.sway",
+                  "match": "\\b(enum)\\b"
+              },
+              {
+                  "comment": "trait keyword",
+                  "name": "keyword.declaration.trait.sway storage.type.sway",
+                  "match": "\\b(trait)\\b"
+              },
+              {
+                  "comment": "struct keyword",
+                  "name": "keyword.declaration.struct.sway storage.type.sway",
+                  "match": "\\b(struct)\\b"
+              },
+              {
+                  "comment": "storage modifiers",
+                  "name": "storage.modifier.sway",
+                  "match": "\\b(abstract|static)\\b"
+              },
+              {
+                  "comment": "other keywords",
+                  "name": "keyword.other.sway",
+                  "match": "\\b(as|async|become|box|dyn|move|final|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\\b"
+              },
+              {
+                  "comment": "fn",
+                  "name": "keyword.other.fn.sway",
+                  "match": "\\bfn\\b"
+              },
+              {
+                  "comment": "crate",
+                  "name": "keyword.other.crate.sway",
+                  "match": "\\bcrate\\b"
+              },
+              {
+                  "comment": "mut",
+                  "name": "storage.modifier.mut.sway",
+                  "match": "\\bmut\\b"
+              },
+              {
+                  "comment": "logical operators",
+                  "name": "keyword.operator.logical.sway",
+                  "match": "(\\^|\\||\\|\\||&&|<<|>>|!)(?!=)"
+              },
+              {
+                  "comment": "logical AND, borrow references",
+                  "name": "keyword.operator.borrow.and.sway",
+                  "match": "&(?![&=])"
+              },
+              {
+                  "comment": "assignment operators",
+                  "name": "keyword.operator.assignment.sway",
+                  "match": "(\\+=|-=|\\*=|/=|%=|\\^=|&=|\\|=|<<=|>>=)"
+              },
+              {
+                  "comment": "single equal",
+                  "name": "keyword.operator.assignment.equal.sway",
+                  "match": "(?<![<>])=(?!=|>)"
+              },
+              {
+                  "comment": "comparison operators",
+                  "name": "keyword.operator.comparison.sway",
+                  "match": "(=(=)?(?!>)|!=|<=|(?<!=)>=)"
+              },
+              {
+                  "comment": "math operators",
+                  "name": "keyword.operator.math.sway",
+                  "match": "(([+%]|(\\*(?!\\w)))(?!=))|(-(?!>))|(/(?!/))"
+              },
+              {
+                  "comment": "less than, greater than (special case)",
+                  "match": "(?:\\b|(?:(\\))|(\\])|(\\})))[ \\t]+([<>])[ \\t]+(?:\\b|(?:(\\()|(\\[)|(\\{)))",
+                  "captures": {
+                      "1": {
+                          "name": "punctuation.brackets.round.sway"
+                      },
+                      "2": {
+                          "name": "punctuation.brackets.square.sway"
+                      },
+                      "3": {
+                          "name": "punctuation.brackets.curly.sway"
+                      },
+                      "4": {
+                          "name": "keyword.operator.comparison.sway"
+                      },
+                      "5": {
+                          "name": "punctuation.brackets.round.sway"
+                      },
+                      "6": {
+                          "name": "punctuation.brackets.square.sway"
+                      },
+                      "7": {
+                          "name": "punctuation.brackets.curly.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "namespace operator",
+                  "name": "keyword.operator.namespace.sway",
+                  "match": "::"
+              },
+              {
+                  "comment": "dereference asterisk",
+                  "match": "(\\*)(?=\\w+)",
+                  "captures": {
+                      "1": {
+                          "name": "keyword.operator.dereference.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "subpattern binding",
+                  "name": "keyword.operator.subpattern.sway",
+                  "match": "@"
+              },
+              {
+                  "comment": "dot access",
+                  "name": "keyword.operator.access.dot.sway",
+                  "match": "\\.(?!\\.)"
+              },
+              {
+                  "comment": "ranges, range patterns",
+                  "name": "keyword.operator.range.sway",
+                  "match": "\\.{2}(=|\\.)?"
+              },
+              {
+                  "comment": "colon",
+                  "name": "keyword.operator.key-value.sway",
+                  "match": ":(?!:)"
+              },
+              {
+                  "comment": "dashrocket, skinny arrow",
+                  "name": "keyword.operator.arrow.skinny.sway",
+                  "match": "->"
+              },
+              {
+                  "comment": "hashrocket, fat arrow",
+                  "name": "keyword.operator.arrow.fat.sway",
+                  "match": "=>"
+              },
+              {
+                  "comment": "dollar macros",
+                  "name": "keyword.operator.macro.dollar.sway",
+                  "match": "\\$"
+              },
+              {
+                  "comment": "question mark operator, questionably sized, macro kleene matcher",
+                  "name": "keyword.operator.question.sway",
+                  "match": "\\?"
+              }
+          ]
+      },
+      "interpolations": {
+          "comment": "curly brace interpolations",
+          "name": "meta.interpolation.sway",
+          "match": "({)[^\"{}]*(})",
+          "captures": {
+              "1": {
+                  "name": "punctuation.definition.interpolation.sway"
+              },
+              "2": {
+                  "name": "punctuation.definition.interpolation.sway"
+              }
+          }
+      },
+      "lifetimes": {
+          "patterns": [
+              {
+                  "comment": "named lifetime parameters",
+                  "match": "(['])([a-zA-Z_][0-9a-zA-Z_]*)(?!['])\\b",
+                  "captures": {
+                      "1": {
+                          "name": "punctuation.definition.lifetime.sway"
+                      },
+                      "2": {
+                          "name": "entity.name.type.lifetime.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "borrowing references to named lifetimes",
+                  "match": "(\\&)(['])([a-zA-Z_][0-9a-zA-Z_]*)(?!['])\\b",
+                  "captures": {
+                      "1": {
+                          "name": "keyword.operator.borrow.sway"
+                      },
+                      "2": {
+                          "name": "punctuation.definition.lifetime.sway"
+                      },
+                      "3": {
+                          "name": "entity.name.type.lifetime.sway"
+                      }
+                  }
+              }
+          ]
+      },
+      "macros": {
+          "patterns": [
+              {
+                  "comment": "macros",
+                  "name": "meta.macro.sway",
+                  "match": "(([a-z_][A-Za-z0-9_]*!)|([A-Z_][A-Za-z0-9_]*!))",
+                  "captures": {
+                      "2": {
+                          "name": "entity.name.function.macro.sway"
+                      },
+                      "3": {
+                          "name": "entity.name.type.macro.sway"
+                      }
+                  }
+              }
+          ]
+      },
+      "namespaces": {
+          "patterns": [
+              {
+                  "comment": "namespace (non-type, non-function path segment)",
+                  "match": "(?<![A-Za-z0-9_])([a-z0-9_]+)((?<!super|self)::)",
+                  "captures": {
+                      "1": {
+                          "name": "entity.name.namespace.sway"
+                      },
+                      "2": {
+                          "name": "keyword.operator.namespace.sway"
+                      }
+                  }
+              }
+          ]
+      },
+      "types": {
+          "patterns": [
+              {
+                  "comment": "numeric types",
+                  "match": "(?<![A-Za-z])(f32|f64|i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)\\b",
+                  "captures": {
+                      "1": {
+                          "name": "entity.name.type.numeric.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "parameterized types",
+                  "begin": "\\b([A-Z][A-Za-z0-9]*)(<)",
+                  "beginCaptures": {
+                      "1": {
+                          "name": "entity.name.type.sway"
+                      },
+                      "2": {
+                          "name": "punctuation.brackets.angle.sway"
+                      }
+                  },
+                  "end": ">",
+                  "endCaptures": {
+                      "0": {
+                          "name": "punctuation.brackets.angle.sway"
+                      }
+                  },
+                  "patterns": [
+                      {
+                          "include": "#block-comments"
+                      },
+                      {
+                          "include": "#comments"
+                      },
+                      {
+                          "include": "#keywords"
+                      },
+                      {
+                          "include": "#lvariables"
+                      },
+                      {
+                          "include": "#lifetimes"
+                      },
+                      {
+                          "include": "#punctuation"
+                      },
+                      {
+                          "include": "#types"
+                      },
+                      {
+                          "include": "#variables"
+                      }
+                  ]
+              },
+              {
+                  "comment": "primitive types",
+                  "name": "entity.name.type.primitive.sway",
+                  "match": "\\b(bool|char|str)\\b"
+              },
+              {
+                  "comment": "trait declarations",
+                  "match": "\\b(trait)\\s+([A-Z][A-Za-z0-9]*)\\b",
+                  "captures": {
+                      "1": {
+                          "name": "keyword.declaration.trait.sway storage.type.sway"
+                      },
+                      "2": {
+                          "name": "entity.name.type.trait.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "struct declarations",
+                  "match": "\\b(struct)\\s+([A-Z][A-Za-z0-9]*)\\b",
+                  "captures": {
+                      "1": {
+                          "name": "keyword.declaration.struct.sway storage.type.sway"
+                      },
+                      "2": {
+                          "name": "entity.name.type.struct.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "enum declarations",
+                  "match": "\\b(enum)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+                  "captures": {
+                      "1": {
+                          "name": "keyword.declaration.enum.sway storage.type.sway"
+                      },
+                      "2": {
+                          "name": "entity.name.type.enum.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "type declarations",
+                  "match": "\\b(type)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+                  "captures": {
+                      "1": {
+                          "name": "keyword.declaration.type.sway storage.type.sway"
+                      },
+                      "2": {
+                          "name": "entity.name.type.declaration.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "types",
+                  "name": "entity.name.type.sway",
+                  "match": "\\b[A-Z][A-Za-z0-9]*\\b(?!!)"
+              }
+          ]
+      },
+      "gtypes": {
+          "patterns": [
+              {
+                  "comment": "option types",
+                  "name": "entity.name.type.option.sway",
+                  "match": "\\b(Some|None)\\b"
+              },
+              {
+                  "comment": "result types",
+                  "name": "entity.name.type.result.sway",
+                  "match": "\\b(Ok|Err)\\b"
+              }
+          ]
+      },
+      "punctuation": {
+          "patterns": [
+              {
+                  "comment": "comma",
+                  "name": "punctuation.comma.sway",
+                  "match": ","
+              },
+              {
+                  "comment": "curly braces",
+                  "name": "punctuation.brackets.curly.sway",
+                  "match": "[{}]"
+              },
+              {
+                  "comment": "parentheses, round brackets",
+                  "name": "punctuation.brackets.round.sway",
+                  "match": "[()]"
+              },
+              {
+                  "comment": "semicolon",
+                  "name": "punctuation.semi.sway",
+                  "match": ";"
+              },
+              {
+                  "comment": "square brackets",
+                  "name": "punctuation.brackets.square.sway",
+                  "match": "[\\[\\]]"
+              },
+              {
+                  "comment": "angle brackets",
+                  "name": "punctuation.brackets.angle.sway",
+                  "match": "(?<!=)[<>]"
+              }
+          ]
+      },
+      "strings": {
+          "patterns": [
+              {
+                  "comment": "double-quoted strings and byte strings",
+                  "name": "string.quoted.double.sway",
+                  "begin": "(b?)(\")",
+                  "beginCaptures": {
+                      "1": {
+                          "name": "string.quoted.byte.raw.sway"
+                      },
+                      "2": {
+                          "name": "punctuation.definition.string.sway"
+                      }
+                  },
+                  "end": "\"",
+                  "endCaptures": {
+                      "0": {
+                          "name": "punctuation.definition.string.sway"
+                      }
+                  },
+                  "patterns": [
+                      {
+                          "include": "#escapes"
+                      },
+                      {
+                          "include": "#interpolations"
+                      }
+                  ]
+              },
+              {
+                  "comment": "double-quoted raw strings and raw byte strings",
+                  "name": "string.quoted.double.sway",
+                  "begin": "(b?r)(#*)(\")",
+                  "beginCaptures": {
+                      "1": {
+                          "name": "string.quoted.byte.raw.sway"
+                      },
+                      "2": {
+                          "name": "punctuation.definition.string.raw.sway"
+                      },
+                      "3": {
+                          "name": "punctuation.definition.string.sway"
+                      }
+                  },
+                  "end": "(\")(\\2)",
+                  "endCaptures": {
+                      "1": {
+                          "name": "punctuation.definition.string.sway"
+                      },
+                      "2": {
+                          "name": "punctuation.definition.string.raw.sway"
+                      }
+                  }
+              },
+              {
+                  "comment": "characters and bytes",
+                  "name": "string.quoted.single.char.sway",
+                  "begin": "(b)?(')",
+                  "beginCaptures": {
+                      "1": {
+                          "name": "string.quoted.byte.raw.sway"
+                      },
+                      "2": {
+                          "name": "punctuation.definition.char.sway"
+                      }
+                  },
+                  "end": "'",
+                  "endCaptures": {
+                      "0": {
+                          "name": "punctuation.definition.char.sway"
+                      }
+                  },
+                  "patterns": [
+                      {
+                          "include": "#escapes"
+                      }
+                  ]
+              }
+          ]
+      },
+      "lvariables": {
+          "patterns": [
+              {
+                  "comment": "self",
+                  "name": "variable.language.self.sway",
+                  "match": "\\b[Ss]elf\\b"
+              },
+              {
+                  "comment": "super",
+                  "name": "variable.language.super.sway",
+                  "match": "\\bsuper\\b"
+              }
+          ]
+      },
+      "variables": {
+          "patterns": [
+              {
+                  "comment": "variables",
+                  "name": "variable.other.sway",
+                  "match": "\\b(?<!(?<!\\.)\\.)(?:r#(?!(crate|[Ss]elf|super)))?[a-z0-9_]+\\b"
+              }
+          ]
+      }
   }
 }

--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -653,12 +653,17 @@
         {
           "comment": "storage keywords",
           "name": "keyword.other.sway storage.type.sway",
-          "match": "\\b(extern|let|macro|mod)\\b"
+          "match": "\\b(extern|macro|mod)\\b"
         },
         {
           "comment": "const keyword",
           "name": "storage.modifier.sway",
           "match": "\\b(const)\\b"
+        },
+        {
+          "comment": "let keyword",
+          "name": "storage.modifier.sway",
+          "match": "\\b(let)\\b"
         },
         {
           "comment": "type keyword",
@@ -682,7 +687,7 @@
         },
         {
           "comment": "struct keyword",
-          "name": "keyword.declaration.struct.sway storage.type.sway",
+          "name": "keyword.declaration.struct.sway",
           "match": "\\b(struct)\\b"
         },
         {
@@ -989,7 +994,7 @@
           "match": "\\b(struct)\\s+([A-Z][A-Za-z0-9]*)\\b",
           "captures": {
             "1": {
-              "name": "keyword.declaration.struct.sway storage.type.sway"
+              "name": "keyword.declaration.struct.sway"
             },
             "2": {
               "name": "entity.name.type.struct.sway"
@@ -1001,7 +1006,7 @@
           "match": "\\b(enum)\\s+([A-Z][A-Za-z0-9_]*)\\b",
           "captures": {
             "1": {
-              "name": "keyword.declaration.enum.sway storage.type.sway"
+              "name": "keyword.declaration.enum.sway"
             },
             "2": {
               "name": "entity.name.type.enum.sway"

--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -1,1229 +1,1227 @@
 {
   "name": "Sway",
-  "fileTypes": [
-      "sw"
-  ],
+  "fileTypes": ["sw"],
   "scopeName": "source.sway",
   "patterns": [
-      {
-          "comment": "boxed slice literal",
-          "begin": "(<)(\\[)",
+    {
+      "comment": "boxed slice literal",
+      "begin": "(<)(\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.brackets.angle.sway"
+        },
+        "2": {
+          "name": "punctuation.brackets.square.sway"
+        }
+      },
+      "end": ">",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.brackets.angle.sway"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#block-comments"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#gtypes"
+        },
+        {
+          "include": "#lvariables"
+        },
+        {
+          "include": "#lifetimes"
+        },
+        {
+          "include": "#punctuation"
+        },
+        {
+          "include": "#types"
+        }
+      ]
+    },
+    {
+      "comment": "macro type metavariables",
+      "name": "meta.macro.metavariable.type.sway",
+      "match": "(\\$)((crate)|([A-Z][A-Za-z0-9_]*))((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.macro.dollar.sway"
+        },
+        "3": {
+          "name": "keyword.other.crate.sway"
+        },
+        "4": {
+          "name": "entity.name.type.metavariable.sway"
+        },
+        "6": {
+          "name": "keyword.operator.key-value.sway"
+        },
+        "7": {
+          "name": "variable.other.metavariable.specifier.sway"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#keywords"
+        }
+      ]
+    },
+    {
+      "comment": "macro metavariables",
+      "name": "meta.macro.metavariable.sway",
+      "match": "(\\$)([a-z][A-Za-z0-9_]*)((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.macro.dollar.sway"
+        },
+        "2": {
+          "name": "variable.other.metavariable.name.sway"
+        },
+        "4": {
+          "name": "keyword.operator.key-value.sway"
+        },
+        "5": {
+          "name": "variable.other.metavariable.specifier.sway"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#keywords"
+        }
+      ]
+    },
+    {
+      "comment": "macro rules",
+      "name": "meta.macro.rules.sway",
+      "match": "\\b(macro_rules!)\\s+(([a-z0-9_]+)|([A-Z][a-z0-9_]*))\\s+(\\{)",
+      "captures": {
+        "1": {
+          "name": "entity.name.function.macro.rules.sway"
+        },
+        "3": {
+          "name": "entity.name.function.macro.sway"
+        },
+        "4": {
+          "name": "entity.name.type.macro.sway"
+        },
+        "5": {
+          "name": "punctuation.brackets.curly.sway"
+        }
+      }
+    },
+    {
+      "comment": "attributes",
+      "name": "meta.attribute.sway",
+      "begin": "(#)(\\!?)(\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.attribute.sway"
+        },
+        "2": {
+          "name": "keyword.operator.attribute.inner.sway"
+        },
+        "3": {
+          "name": "punctuation.brackets.attribute.sway"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.brackets.attribute.sway"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#block-comments"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#lifetimes"
+        },
+        {
+          "include": "#punctuation"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#gtypes"
+        },
+        {
+          "include": "#types"
+        }
+      ]
+    },
+    {
+      "comment": "modules",
+      "match": "(mod)\\s+((?:r#(?!crate|[Ss]elf|super))?[a-z][A-Za-z0-9_]*)",
+      "captures": {
+        "1": {
+          "name": "storage.type.sway"
+        },
+        "2": {
+          "name": "entity.name.module.sway"
+        }
+      }
+    },
+    {
+      "comment": "external crate imports",
+      "name": "meta.import.sway",
+      "begin": "\\b(extern)\\s+(crate)",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.sway"
+        },
+        "2": {
+          "name": "keyword.other.crate.sway"
+        }
+      },
+      "end": ";",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.semi.sway"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#block-comments"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#punctuation"
+        }
+      ]
+    },
+    {
+      "comment": "use statements",
+      "name": "meta.use.sway",
+      "begin": "\\b(use)\\s",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.sway"
+        }
+      },
+      "end": ";",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.semi.sway"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#block-comments"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#namespaces"
+        },
+        {
+          "include": "#punctuation"
+        },
+        {
+          "include": "#types"
+        },
+        {
+          "include": "#lvariables"
+        }
+      ]
+    },
+    {
+      "include": "#block-comments"
+    },
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#lvariables"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#gtypes"
+    },
+    {
+      "include": "#functions"
+    },
+    {
+      "include": "#types"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#lifetimes"
+    },
+    {
+      "include": "#macros"
+    },
+    {
+      "include": "#namespaces"
+    },
+    {
+      "include": "#punctuation"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#variables"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "comment": "documentation comments",
+          "name": "comment.line.documentation.sway",
+          "match": "^\\s*///.*"
+        },
+        {
+          "comment": "line comments",
+          "name": "comment.line.double-slash.sway",
+          "match": "\\s*//.*"
+        }
+      ]
+    },
+    "block-comments": {
+      "patterns": [
+        {
+          "comment": "empty block comments",
+          "name": "comment.block.sway",
+          "match": "/\\*\\*/"
+        },
+        {
+          "comment": "block documentation comments",
+          "name": "comment.block.documentation.sway",
+          "begin": "/\\*\\*",
+          "end": "\\*/",
+          "patterns": [
+            {
+              "include": "#block-comments"
+            }
+          ]
+        },
+        {
+          "comment": "block comments",
+          "name": "comment.block.sway",
+          "begin": "/\\*(?!\\*)",
+          "end": "\\*/",
+          "patterns": [
+            {
+              "include": "#block-comments"
+            }
+          ]
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "comment": "ALL CAPS constants",
+          "name": "constant.other.caps.sway",
+          "match": "\\b[A-Z]{2}[A-Z0-9_]*\\b"
+        },
+        {
+          "comment": "constant declarations",
+          "match": "\\b(const)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+          "captures": {
+            "1": {
+              "name": "storage.type.sway"
+            },
+            "2": {
+              "name": "constant.other.caps.sway"
+            }
+          }
+        },
+        {
+          "comment": "decimal integers and floats",
+          "name": "constant.numeric.decimal.sway",
+          "match": "\\b\\d[\\d_]*(\\.?)[\\d_]*(?:(E)([+-])([\\d_]+))?(f32|f64|i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.dot.decimal.sway"
+            },
+            "2": {
+              "name": "keyword.operator.exponent.sway"
+            },
+            "3": {
+              "name": "keyword.operator.exponent.sign.sway"
+            },
+            "4": {
+              "name": "constant.numeric.decimal.exponent.mantissa.sway"
+            },
+            "5": {
+              "name": "entity.name.type.numeric.sway"
+            }
+          }
+        },
+        {
+          "comment": "hexadecimal integers",
+          "name": "constant.numeric.hex.sway",
+          "match": "\\b0x[\\da-fA-F_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.sway"
+            }
+          }
+        },
+        {
+          "comment": "octal integers",
+          "name": "constant.numeric.oct.sway",
+          "match": "\\b0o[0-7_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.sway"
+            }
+          }
+        },
+        {
+          "comment": "binary integers",
+          "name": "constant.numeric.bin.sway",
+          "match": "\\b0b[01_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.sway"
+            }
+          }
+        },
+        {
+          "comment": "booleans",
+          "name": "constant.language.bool.sway",
+          "match": "\\b(true|false)\\b"
+        }
+      ]
+    },
+    "escapes": {
+      "comment": "escapes: ASCII, byte, Unicode, quote, regex",
+      "name": "constant.character.escape.sway",
+      "match": "(\\\\)(?:(?:(x[0-7][0-7a-fA-F])|(u(\\{)[\\da-fA-F]{4,6}(\\}))|.))",
+      "captures": {
+        "1": {
+          "name": "constant.character.escape.backslash.sway"
+        },
+        "2": {
+          "name": "constant.character.escape.bit.sway"
+        },
+        "3": {
+          "name": "constant.character.escape.unicode.sway"
+        },
+        "4": {
+          "name": "constant.character.escape.unicode.punctuation.sway"
+        },
+        "5": {
+          "name": "constant.character.escape.unicode.punctuation.sway"
+        }
+      }
+    },
+    "functions": {
+      "patterns": [
+        {
+          "comment": "pub as a function",
+          "match": "\\b(pub)(\\()",
+          "captures": {
+            "1": {
+              "name": "keyword.other.sway"
+            },
+            "2": {
+              "name": "punctuation.brackets.round.sway"
+            }
+          }
+        },
+        {
+          "comment": "function definition",
+          "name": "meta.function.definition.sway",
+          "begin": "\\b(fn)\\s+((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)((\\()|(<))",
           "beginCaptures": {
-              "1": {
-                  "name": "punctuation.brackets.angle.sway"
-              },
-              "2": {
-                  "name": "punctuation.brackets.square.sway"
-              }
+            "1": {
+              "name": "keyword.other.fn.sway"
+            },
+            "2": {
+              "name": "entity.name.function.sway"
+            },
+            "4": {
+              "name": "punctuation.brackets.round.sway"
+            },
+            "5": {
+              "name": "punctuation.brackets.angle.sway"
+            }
+          },
+          "end": "\\{|;",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.curly.sway"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#gtypes"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#lifetimes"
+            },
+            {
+              "include": "#macros"
+            },
+            {
+              "include": "#namespaces"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
+          "comment": "function/method calls, chaining",
+          "name": "meta.function.call.sway",
+          "begin": "((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.sway"
+            },
+            "2": {
+              "name": "punctuation.brackets.round.sway"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.round.sway"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#gtypes"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#lifetimes"
+            },
+            {
+              "include": "#macros"
+            },
+            {
+              "include": "#namespaces"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
+          "comment": "function/method calls with turbofish",
+          "name": "meta.function.call.sway",
+          "begin": "((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)(?=::<.*>\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.sway"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.round.sway"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#gtypes"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#lifetimes"
+            },
+            {
+              "include": "#macros"
+            },
+            {
+              "include": "#namespaces"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "comment": "control flow keywords",
+          "name": "keyword.control.sway",
+          "match": "\\b(await|break|continue|do|else|for|if|loop|match|return|try|while|yield)\\b"
+        },
+        {
+          "comment": "storage keywords",
+          "name": "keyword.other.sway storage.type.sway",
+          "match": "\\b(extern|let|macro|mod)\\b"
+        },
+        {
+          "comment": "const keyword",
+          "name": "storage.modifier.sway",
+          "match": "\\b(const)\\b"
+        },
+        {
+          "comment": "type keyword",
+          "name": "keyword.declaration.type.sway storage.type.sway",
+          "match": "\\b(type)\\b"
+        },
+        {
+          "comment": "enum keyword",
+          "name": "keyword.declaration.enum.sway storage.type.sway",
+          "match": "\\b(enum)\\b"
+        },
+        {
+          "comment": "trait keyword",
+          "name": "keyword.declaration.trait.sway storage.type.sway",
+          "match": "\\b(trait)\\b"
+        },
+        {
+          "comment": "abi keyword",
+          "name": "keyword.declaration.abi.sway storage.type.sway",
+          "match": "\\b(abi)\\b"
+        },
+        {
+          "comment": "struct keyword",
+          "name": "keyword.declaration.struct.sway storage.type.sway",
+          "match": "\\b(struct)\\b"
+        },
+        {
+          "comment": "storage modifiers",
+          "name": "storage.modifier.sway",
+          "match": "\\b(abstract|static)\\b"
+        },
+        {
+          "comment": "other keywords",
+          "name": "keyword.other.sway",
+          "match": "\\b(as|async|become|box|dyn|move|final|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\\b"
+        },
+        {
+          "comment": "fn",
+          "name": "keyword.other.fn.sway",
+          "match": "\\bfn\\b"
+        },
+        {
+          "comment": "crate",
+          "name": "keyword.other.crate.sway",
+          "match": "\\bcrate\\b"
+        },
+        {
+          "comment": "mut",
+          "name": "storage.modifier.mut.sway",
+          "match": "\\bmut\\b"
+        },
+        {
+          "comment": "logical operators",
+          "name": "keyword.operator.logical.sway",
+          "match": "(\\^|\\||\\|\\||&&|<<|>>|!)(?!=)"
+        },
+        {
+          "comment": "logical AND, borrow references",
+          "name": "keyword.operator.borrow.and.sway",
+          "match": "&(?![&=])"
+        },
+        {
+          "comment": "assignment operators",
+          "name": "keyword.operator.assignment.sway",
+          "match": "(\\+=|-=|\\*=|/=|%=|\\^=|&=|\\|=|<<=|>>=)"
+        },
+        {
+          "comment": "single equal",
+          "name": "keyword.operator.assignment.equal.sway",
+          "match": "(?<![<>])=(?!=|>)"
+        },
+        {
+          "comment": "comparison operators",
+          "name": "keyword.operator.comparison.sway",
+          "match": "(=(=)?(?!>)|!=|<=|(?<!=)>=)"
+        },
+        {
+          "comment": "math operators",
+          "name": "keyword.operator.math.sway",
+          "match": "(([+%]|(\\*(?!\\w)))(?!=))|(-(?!>))|(/(?!/))"
+        },
+        {
+          "comment": "less than, greater than (special case)",
+          "match": "(?:\\b|(?:(\\))|(\\])|(\\})))[ \\t]+([<>])[ \\t]+(?:\\b|(?:(\\()|(\\[)|(\\{)))",
+          "captures": {
+            "1": {
+              "name": "punctuation.brackets.round.sway"
+            },
+            "2": {
+              "name": "punctuation.brackets.square.sway"
+            },
+            "3": {
+              "name": "punctuation.brackets.curly.sway"
+            },
+            "4": {
+              "name": "keyword.operator.comparison.sway"
+            },
+            "5": {
+              "name": "punctuation.brackets.round.sway"
+            },
+            "6": {
+              "name": "punctuation.brackets.square.sway"
+            },
+            "7": {
+              "name": "punctuation.brackets.curly.sway"
+            }
+          }
+        },
+        {
+          "comment": "namespace operator",
+          "name": "keyword.operator.namespace.sway",
+          "match": "::"
+        },
+        {
+          "comment": "dereference asterisk",
+          "match": "(\\*)(?=\\w+)",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.dereference.sway"
+            }
+          }
+        },
+        {
+          "comment": "subpattern binding",
+          "name": "keyword.operator.subpattern.sway",
+          "match": "@"
+        },
+        {
+          "comment": "dot access",
+          "name": "keyword.operator.access.dot.sway",
+          "match": "\\.(?!\\.)"
+        },
+        {
+          "comment": "ranges, range patterns",
+          "name": "keyword.operator.range.sway",
+          "match": "\\.{2}(=|\\.)?"
+        },
+        {
+          "comment": "colon",
+          "name": "keyword.operator.key-value.sway",
+          "match": ":(?!:)"
+        },
+        {
+          "comment": "dashrocket, skinny arrow",
+          "name": "keyword.operator.arrow.skinny.sway",
+          "match": "->"
+        },
+        {
+          "comment": "hashrocket, fat arrow",
+          "name": "keyword.operator.arrow.fat.sway",
+          "match": "=>"
+        },
+        {
+          "comment": "dollar macros",
+          "name": "keyword.operator.macro.dollar.sway",
+          "match": "\\$"
+        },
+        {
+          "comment": "question mark operator, questionably sized, macro kleene matcher",
+          "name": "keyword.operator.question.sway",
+          "match": "\\?"
+        }
+      ]
+    },
+    "interpolations": {
+      "comment": "curly brace interpolations",
+      "name": "meta.interpolation.sway",
+      "match": "({)[^\"{}]*(})",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.interpolation.sway"
+        },
+        "2": {
+          "name": "punctuation.definition.interpolation.sway"
+        }
+      }
+    },
+    "lifetimes": {
+      "patterns": [
+        {
+          "comment": "named lifetime parameters",
+          "match": "(['])([a-zA-Z_][0-9a-zA-Z_]*)(?!['])\\b",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.lifetime.sway"
+            },
+            "2": {
+              "name": "entity.name.type.lifetime.sway"
+            }
+          }
+        },
+        {
+          "comment": "borrowing references to named lifetimes",
+          "match": "(\\&)(['])([a-zA-Z_][0-9a-zA-Z_]*)(?!['])\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.borrow.sway"
+            },
+            "2": {
+              "name": "punctuation.definition.lifetime.sway"
+            },
+            "3": {
+              "name": "entity.name.type.lifetime.sway"
+            }
+          }
+        }
+      ]
+    },
+    "macros": {
+      "patterns": [
+        {
+          "comment": "macros",
+          "name": "meta.macro.sway",
+          "match": "(([a-z_][A-Za-z0-9_]*!)|([A-Z_][A-Za-z0-9_]*!))",
+          "captures": {
+            "2": {
+              "name": "entity.name.function.macro.sway"
+            },
+            "3": {
+              "name": "entity.name.type.macro.sway"
+            }
+          }
+        }
+      ]
+    },
+    "namespaces": {
+      "patterns": [
+        {
+          "comment": "namespace (non-type, non-function path segment)",
+          "match": "(?<![A-Za-z0-9_])([a-z0-9_]+)((?<!super|self)::)",
+          "captures": {
+            "1": {
+              "name": "entity.name.namespace.sway"
+            },
+            "2": {
+              "name": "keyword.operator.namespace.sway"
+            }
+          }
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "comment": "numeric types",
+          "match": "(?<![A-Za-z])(f32|f64|i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)\\b",
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.sway"
+            }
+          }
+        },
+        {
+          "comment": "parameterized types",
+          "begin": "\\b([A-Z][A-Za-z0-9]*)(<)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.type.sway"
+            },
+            "2": {
+              "name": "punctuation.brackets.angle.sway"
+            }
           },
           "end": ">",
           "endCaptures": {
-              "0": {
-                  "name": "punctuation.brackets.angle.sway"
-              }
+            "0": {
+              "name": "punctuation.brackets.angle.sway"
+            }
           },
           "patterns": [
-              {
-                  "include": "#block-comments"
-              },
-              {
-                  "include": "#comments"
-              },
-              {
-                  "include": "#gtypes"
-              },
-              {
-                  "include": "#lvariables"
-              },
-              {
-                  "include": "#lifetimes"
-              },
-              {
-                  "include": "#punctuation"
-              },
-              {
-                  "include": "#types"
-              }
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#lifetimes"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
           ]
-      },
-      {
-          "comment": "macro type metavariables",
-          "name": "meta.macro.metavariable.type.sway",
-          "match": "(\\$)((crate)|([A-Z][A-Za-z0-9_]*))((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?",
+        },
+        {
+          "comment": "primitive types",
+          "name": "entity.name.type.primitive.sway",
+          "match": "\\b(bool|char|str)\\b"
+        },
+        {
+          "comment": "trait declarations",
+          "match": "\\b(trait)\\s+([A-Z][A-Za-z0-9]*)\\b",
           "captures": {
-              "1": {
-                  "name": "keyword.operator.macro.dollar.sway"
-              },
-              "3": {
-                  "name": "keyword.other.crate.sway"
-              },
-              "4": {
-                  "name": "entity.name.type.metavariable.sway"
-              },
-              "6": {
-                  "name": "keyword.operator.key-value.sway"
-              },
-              "7": {
-                  "name": "variable.other.metavariable.specifier.sway"
-              }
-          },
-          "patterns": [
-              {
-                  "include": "#keywords"
-              }
-          ]
-      },
-      {
-          "comment": "macro metavariables",
-          "name": "meta.macro.metavariable.sway",
-          "match": "(\\$)([a-z][A-Za-z0-9_]*)((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?",
-          "captures": {
-              "1": {
-                  "name": "keyword.operator.macro.dollar.sway"
-              },
-              "2": {
-                  "name": "variable.other.metavariable.name.sway"
-              },
-              "4": {
-                  "name": "keyword.operator.key-value.sway"
-              },
-              "5": {
-                  "name": "variable.other.metavariable.specifier.sway"
-              }
-          },
-          "patterns": [
-              {
-                  "include": "#keywords"
-              }
-          ]
-      },
-      {
-          "comment": "macro rules",
-          "name": "meta.macro.rules.sway",
-          "match": "\\b(macro_rules!)\\s+(([a-z0-9_]+)|([A-Z][a-z0-9_]*))\\s+(\\{)",
-          "captures": {
-              "1": {
-                  "name": "entity.name.function.macro.rules.sway"
-              },
-              "3": {
-                  "name": "entity.name.function.macro.sway"
-              },
-              "4": {
-                  "name": "entity.name.type.macro.sway"
-              },
-              "5": {
-                  "name": "punctuation.brackets.curly.sway"
-              }
+            "1": {
+              "name": "keyword.declaration.trait.sway storage.type.sway"
+            },
+            "2": {
+              "name": "entity.name.type.trait.sway"
+            }
           }
-      },
-      {
-          "comment": "attributes",
-          "name": "meta.attribute.sway",
-          "begin": "(#)(\\!?)(\\[)",
+        },
+        {
+          "comment": "abi declarations",
+          "match": "\\b(abi)\\s+([A-Z][A-Za-z0-9]*)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.abi.sway storage.type.sway"
+            },
+            "2": {
+              "name": "entity.name.type.abi.sway"
+            }
+          }
+        },
+        {
+          "comment": "struct declarations",
+          "match": "\\b(struct)\\s+([A-Z][A-Za-z0-9]*)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.struct.sway storage.type.sway"
+            },
+            "2": {
+              "name": "entity.name.type.struct.sway"
+            }
+          }
+        },
+        {
+          "comment": "enum declarations",
+          "match": "\\b(enum)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.enum.sway storage.type.sway"
+            },
+            "2": {
+              "name": "entity.name.type.enum.sway"
+            }
+          }
+        },
+        {
+          "comment": "type declarations",
+          "match": "\\b(type)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.type.sway storage.type.sway"
+            },
+            "2": {
+              "name": "entity.name.type.declaration.sway"
+            }
+          }
+        },
+        {
+          "comment": "types",
+          "name": "entity.name.type.sway",
+          "match": "\\b[A-Z][A-Za-z0-9]*\\b(?!!)"
+        },
+        {
+          "comment": "top level declaration",
+          "begin": "\\b(library)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+          "end": "[\\{\\(;]",
           "beginCaptures": {
-              "1": {
-                  "name": "punctuation.definition.attribute.sway"
-              },
-              "2": {
-                  "name": "keyword.operator.attribute.inner.sway"
-              },
-              "3": {
-                  "name": "punctuation.brackets.attribute.sway"
-              }
-          },
-          "end": "\\]",
-          "endCaptures": {
-              "0": {
-                  "name": "punctuation.brackets.attribute.sway"
-              }
+            "1": {
+              "name": "storage.type.sway"
+            },
+            "2": {
+              "name": "entity.name.type.sway"
+            }
           },
           "patterns": [
-              {
-                  "include": "#block-comments"
-              },
-              {
-                  "include": "#comments"
-              },
-              {
-                  "include": "#keywords"
-              },
-              {
-                  "include": "#lifetimes"
-              },
-              {
-                  "include": "#punctuation"
-              },
-              {
-                  "include": "#strings"
-              },
-              {
-                  "include": "#gtypes"
-              },
-              {
-                  "include": "#types"
-              }
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#namespaces"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#lvariables"
+            }
           ]
-      },
-      {
-          "comment": "modules",
-          "match": "(mod)\\s+((?:r#(?!crate|[Ss]elf|super))?[a-z][A-Za-z0-9_]*)",
+        },
+        {
+          "comment": "top level declaration without name",
+          "match": "(contract|script|predicate);",
           "captures": {
-              "1": {
-                  "name": "storage.type.sway"
-              },
-              "2": {
-                  "name": "entity.name.module.sway"
-              }
+            "1": {
+              "name": "storage.type.sway"
+            }
           }
-      },
-      {
-          "comment": "external crate imports",
-          "name": "meta.import.sway",
-          "begin": "\\b(extern)\\s+(crate)",
+        }
+      ]
+    },
+    "gtypes": {
+      "patterns": [
+        {
+          "comment": "option types",
+          "name": "entity.name.type.option.sway",
+          "match": "\\b(Some|None)\\b"
+        },
+        {
+          "comment": "result types",
+          "name": "entity.name.type.result.sway",
+          "match": "\\b(Ok|Err)\\b"
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        {
+          "comment": "comma",
+          "name": "punctuation.comma.sway",
+          "match": ","
+        },
+        {
+          "comment": "curly braces",
+          "name": "punctuation.brackets.curly.sway",
+          "match": "[{}]"
+        },
+        {
+          "comment": "parentheses, round brackets",
+          "name": "punctuation.brackets.round.sway",
+          "match": "[()]"
+        },
+        {
+          "comment": "semicolon",
+          "name": "punctuation.semi.sway",
+          "match": ";"
+        },
+        {
+          "comment": "square brackets",
+          "name": "punctuation.brackets.square.sway",
+          "match": "[\\[\\]]"
+        },
+        {
+          "comment": "angle brackets",
+          "name": "punctuation.brackets.angle.sway",
+          "match": "(?<!=)[<>]"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "comment": "double-quoted strings and byte strings",
+          "name": "string.quoted.double.sway",
+          "begin": "(b?)(\")",
           "beginCaptures": {
-              "1": {
-                  "name": "storage.type.sway"
-              },
-              "2": {
-                  "name": "keyword.other.crate.sway"
-              }
+            "1": {
+              "name": "string.quoted.byte.raw.sway"
+            },
+            "2": {
+              "name": "punctuation.definition.string.sway"
+            }
           },
-          "end": ";",
+          "end": "\"",
           "endCaptures": {
-              "0": {
-                  "name": "punctuation.semi.sway"
-              }
+            "0": {
+              "name": "punctuation.definition.string.sway"
+            }
           },
           "patterns": [
-              {
-                  "include": "#block-comments"
-              },
-              {
-                  "include": "#comments"
-              },
-              {
-                  "include": "#keywords"
-              },
-              {
-                  "include": "#punctuation"
-              }
+            {
+              "include": "#escapes"
+            },
+            {
+              "include": "#interpolations"
+            }
           ]
-      },
-      {
-          "comment": "use statements",
-          "name": "meta.use.sway",
-          "begin": "\\b(use)\\s",
+        },
+        {
+          "comment": "double-quoted raw strings and raw byte strings",
+          "name": "string.quoted.double.sway",
+          "begin": "(b?r)(#*)(\")",
           "beginCaptures": {
-              "1": {
-                  "name": "keyword.other.sway"
-              }
+            "1": {
+              "name": "string.quoted.byte.raw.sway"
+            },
+            "2": {
+              "name": "punctuation.definition.string.raw.sway"
+            },
+            "3": {
+              "name": "punctuation.definition.string.sway"
+            }
           },
-          "end": ";",
+          "end": "(\")(\\2)",
           "endCaptures": {
-              "0": {
-                  "name": "punctuation.semi.sway"
-              }
+            "1": {
+              "name": "punctuation.definition.string.sway"
+            },
+            "2": {
+              "name": "punctuation.definition.string.raw.sway"
+            }
+          }
+        },
+        {
+          "comment": "characters and bytes",
+          "name": "string.quoted.single.char.sway",
+          "begin": "(b)?(')",
+          "beginCaptures": {
+            "1": {
+              "name": "string.quoted.byte.raw.sway"
+            },
+            "2": {
+              "name": "punctuation.definition.char.sway"
+            }
+          },
+          "end": "'",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.char.sway"
+            }
           },
           "patterns": [
-              {
-                  "include": "#block-comments"
-              },
-              {
-                  "include": "#comments"
-              },
-              {
-                  "include": "#keywords"
-              },
-              {
-                  "include": "#namespaces"
-              },
-              {
-                  "include": "#punctuation"
-              },
-              {
-                  "include": "#types"
-              },
-              {
-                  "include": "#lvariables"
-              }
+            {
+              "include": "#escapes"
+            }
           ]
-      },
-      {
-          "include": "#block-comments"
-      },
-      {
-          "include": "#comments"
-      },
-      {
-          "include": "#lvariables"
-      },
-      {
-          "include": "#constants"
-      },
-      {
-          "include": "#gtypes"
-      },
-      {
-          "include": "#functions"
-      },
-      {
-          "include": "#types"
-      },
-      {
-          "include": "#keywords"
-      },
-      {
-          "include": "#lifetimes"
-      },
-      {
-          "include": "#macros"
-      },
-      {
-          "include": "#namespaces"
-      },
-      {
-          "include": "#punctuation"
-      },
-      {
-          "include": "#strings"
-      },
-      {
-          "include": "#variables"
-      }
-  ],
-  "repository": {
-      "comments": {
-          "patterns": [
-              {
-                  "comment": "documentation comments",
-                  "name": "comment.line.documentation.sway",
-                  "match": "^\\s*///.*"
-              },
-              {
-                  "comment": "line comments",
-                  "name": "comment.line.double-slash.sway",
-                  "match": "\\s*//.*"
-              }
-          ]
-      },
-      "block-comments": {
-          "patterns": [
-              {
-                  "comment": "empty block comments",
-                  "name": "comment.block.sway",
-                  "match": "/\\*\\*/"
-              },
-              {
-                  "comment": "block documentation comments",
-                  "name": "comment.block.documentation.sway",
-                  "begin": "/\\*\\*",
-                  "end": "\\*/",
-                  "patterns": [
-                      {
-                          "include": "#block-comments"
-                      }
-                  ]
-              },
-              {
-                  "comment": "block comments",
-                  "name": "comment.block.sway",
-                  "begin": "/\\*(?!\\*)",
-                  "end": "\\*/",
-                  "patterns": [
-                      {
-                          "include": "#block-comments"
-                      }
-                  ]
-              }
-          ]
-      },
-      "constants": {
-          "patterns": [
-              {
-                  "comment": "ALL CAPS constants",
-                  "name": "constant.other.caps.sway",
-                  "match": "\\b[A-Z]{2}[A-Z0-9_]*\\b"
-              },
-              {
-                  "comment": "constant declarations",
-                  "match": "\\b(const)\\s+([A-Z][A-Za-z0-9_]*)\\b",
-                  "captures": {
-                      "1": {
-                          "name": "storage.type.sway"
-                      },
-                      "2": {
-                          "name": "constant.other.caps.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "decimal integers and floats",
-                  "name": "constant.numeric.decimal.sway",
-                  "match": "\\b\\d[\\d_]*(\\.?)[\\d_]*(?:(E)([+-])([\\d_]+))?(f32|f64|i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
-                  "captures": {
-                      "1": {
-                          "name": "punctuation.separator.dot.decimal.sway"
-                      },
-                      "2": {
-                          "name": "keyword.operator.exponent.sway"
-                      },
-                      "3": {
-                          "name": "keyword.operator.exponent.sign.sway"
-                      },
-                      "4": {
-                          "name": "constant.numeric.decimal.exponent.mantissa.sway"
-                      },
-                      "5": {
-                          "name": "entity.name.type.numeric.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "hexadecimal integers",
-                  "name": "constant.numeric.hex.sway",
-                  "match": "\\b0x[\\da-fA-F_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
-                  "captures": {
-                      "1": {
-                          "name": "entity.name.type.numeric.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "octal integers",
-                  "name": "constant.numeric.oct.sway",
-                  "match": "\\b0o[0-7_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
-                  "captures": {
-                      "1": {
-                          "name": "entity.name.type.numeric.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "binary integers",
-                  "name": "constant.numeric.bin.sway",
-                  "match": "\\b0b[01_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
-                  "captures": {
-                      "1": {
-                          "name": "entity.name.type.numeric.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "booleans",
-                  "name": "constant.language.bool.sway",
-                  "match": "\\b(true|false)\\b"
-              }
-          ]
-      },
-      "escapes": {
-          "comment": "escapes: ASCII, byte, Unicode, quote, regex",
-          "name": "constant.character.escape.sway",
-          "match": "(\\\\)(?:(?:(x[0-7][0-7a-fA-F])|(u(\\{)[\\da-fA-F]{4,6}(\\}))|.))",
-          "captures": {
-              "1": {
-                  "name": "constant.character.escape.backslash.sway"
-              },
-              "2": {
-                  "name": "constant.character.escape.bit.sway"
-              },
-              "3": {
-                  "name": "constant.character.escape.unicode.sway"
-              },
-              "4": {
-                  "name": "constant.character.escape.unicode.punctuation.sway"
-              },
-              "5": {
-                  "name": "constant.character.escape.unicode.punctuation.sway"
-              }
-          }
-      },
-      "functions": {
-          "patterns": [
-              {
-                  "comment": "pub as a function",
-                  "match": "\\b(pub)(\\()",
-                  "captures": {
-                      "1": {
-                          "name": "keyword.other.sway"
-                      },
-                      "2": {
-                          "name": "punctuation.brackets.round.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "function definition",
-                  "name": "meta.function.definition.sway",
-                  "begin": "\\b(fn)\\s+((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)((\\()|(<))",
-                  "beginCaptures": {
-                      "1": {
-                          "name": "keyword.other.fn.sway"
-                      },
-                      "2": {
-                          "name": "entity.name.function.sway"
-                      },
-                      "4": {
-                          "name": "punctuation.brackets.round.sway"
-                      },
-                      "5": {
-                          "name": "punctuation.brackets.angle.sway"
-                      }
-                  },
-                  "end": "\\{|;",
-                  "endCaptures": {
-                      "0": {
-                          "name": "punctuation.brackets.curly.sway"
-                      }
-                  },
-                  "patterns": [
-                      {
-                          "include": "#block-comments"
-                      },
-                      {
-                          "include": "#comments"
-                      },
-                      {
-                          "include": "#keywords"
-                      },
-                      {
-                          "include": "#lvariables"
-                      },
-                      {
-                          "include": "#constants"
-                      },
-                      {
-                          "include": "#gtypes"
-                      },
-                      {
-                          "include": "#functions"
-                      },
-                      {
-                          "include": "#lifetimes"
-                      },
-                      {
-                          "include": "#macros"
-                      },
-                      {
-                          "include": "#namespaces"
-                      },
-                      {
-                          "include": "#punctuation"
-                      },
-                      {
-                          "include": "#strings"
-                      },
-                      {
-                          "include": "#types"
-                      },
-                      {
-                          "include": "#variables"
-                      }
-                  ]
-              },
-              {
-                  "comment": "function/method calls, chaining",
-                  "name": "meta.function.call.sway",
-                  "begin": "((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)(\\()",
-                  "beginCaptures": {
-                      "1": {
-                          "name": "entity.name.function.sway"
-                      },
-                      "2": {
-                          "name": "punctuation.brackets.round.sway"
-                      }
-                  },
-                  "end": "\\)",
-                  "endCaptures": {
-                      "0": {
-                          "name": "punctuation.brackets.round.sway"
-                      }
-                  },
-                  "patterns": [
-                      {
-                          "include": "#block-comments"
-                      },
-                      {
-                          "include": "#comments"
-                      },
-                      {
-                          "include": "#keywords"
-                      },
-                      {
-                          "include": "#lvariables"
-                      },
-                      {
-                          "include": "#constants"
-                      },
-                      {
-                          "include": "#gtypes"
-                      },
-                      {
-                          "include": "#functions"
-                      },
-                      {
-                          "include": "#lifetimes"
-                      },
-                      {
-                          "include": "#macros"
-                      },
-                      {
-                          "include": "#namespaces"
-                      },
-                      {
-                          "include": "#punctuation"
-                      },
-                      {
-                          "include": "#strings"
-                      },
-                      {
-                          "include": "#types"
-                      },
-                      {
-                          "include": "#variables"
-                      }
-                  ]
-              },
-              {
-                  "comment": "function/method calls with turbofish",
-                  "name": "meta.function.call.sway",
-                  "begin": "((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)(?=::<.*>\\()",
-                  "beginCaptures": {
-                      "1": {
-                          "name": "entity.name.function.sway"
-                      }
-                  },
-                  "end": "\\)",
-                  "endCaptures": {
-                      "0": {
-                          "name": "punctuation.brackets.round.sway"
-                      }
-                  },
-                  "patterns": [
-                      {
-                          "include": "#block-comments"
-                      },
-                      {
-                          "include": "#comments"
-                      },
-                      {
-                          "include": "#keywords"
-                      },
-                      {
-                          "include": "#lvariables"
-                      },
-                      {
-                          "include": "#constants"
-                      },
-                      {
-                          "include": "#gtypes"
-                      },
-                      {
-                          "include": "#functions"
-                      },
-                      {
-                          "include": "#lifetimes"
-                      },
-                      {
-                          "include": "#macros"
-                      },
-                      {
-                          "include": "#namespaces"
-                      },
-                      {
-                          "include": "#punctuation"
-                      },
-                      {
-                          "include": "#strings"
-                      },
-                      {
-                          "include": "#types"
-                      },
-                      {
-                          "include": "#variables"
-                      }
-                  ]
-              }
-          ]
-      },
-      "keywords": {
-          "patterns": [
-              {
-                  "comment": "control flow keywords",
-                  "name": "keyword.control.sway",
-                  "match": "\\b(await|break|continue|do|else|for|if|loop|match|return|try|while|yield)\\b"
-              },
-              {
-                  "comment": "storage keywords",
-                  "name": "keyword.other.sway storage.type.sway",
-                  "match": "\\b(extern|let|macro|mod)\\b"
-              },
-              {
-                  "comment": "const keyword",
-                  "name": "storage.modifier.sway",
-                  "match": "\\b(const)\\b"
-              },
-              {
-                  "comment": "type keyword",
-                  "name": "keyword.declaration.type.sway storage.type.sway",
-                  "match": "\\b(type)\\b"
-              },
-              {
-                  "comment": "enum keyword",
-                  "name": "keyword.declaration.enum.sway storage.type.sway",
-                  "match": "\\b(enum)\\b"
-              },
-              {
-                  "comment": "trait keyword",
-                  "name": "keyword.declaration.trait.sway storage.type.sway",
-                  "match": "\\b(trait)\\b"
-              },
-              {
-                "comment": "abi keyword",
-                "name": "keyword.declaration.abi.sway storage.type.sway",
-                "match": "\\b(abi)\\b"
-              },
-              {
-                  "comment": "struct keyword",
-                  "name": "keyword.declaration.struct.sway storage.type.sway",
-                  "match": "\\b(struct)\\b"
-              },
-              {
-                  "comment": "storage modifiers",
-                  "name": "storage.modifier.sway",
-                  "match": "\\b(abstract|static)\\b"
-              },
-              {
-                  "comment": "other keywords",
-                  "name": "keyword.other.sway",
-                  "match": "\\b(as|async|become|box|dyn|move|final|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\\b"
-              },
-              {
-                  "comment": "fn",
-                  "name": "keyword.other.fn.sway",
-                  "match": "\\bfn\\b"
-              },
-              {
-                  "comment": "crate",
-                  "name": "keyword.other.crate.sway",
-                  "match": "\\bcrate\\b"
-              },
-              {
-                  "comment": "mut",
-                  "name": "storage.modifier.mut.sway",
-                  "match": "\\bmut\\b"
-              },
-              {
-                  "comment": "logical operators",
-                  "name": "keyword.operator.logical.sway",
-                  "match": "(\\^|\\||\\|\\||&&|<<|>>|!)(?!=)"
-              },
-              {
-                  "comment": "logical AND, borrow references",
-                  "name": "keyword.operator.borrow.and.sway",
-                  "match": "&(?![&=])"
-              },
-              {
-                  "comment": "assignment operators",
-                  "name": "keyword.operator.assignment.sway",
-                  "match": "(\\+=|-=|\\*=|/=|%=|\\^=|&=|\\|=|<<=|>>=)"
-              },
-              {
-                  "comment": "single equal",
-                  "name": "keyword.operator.assignment.equal.sway",
-                  "match": "(?<![<>])=(?!=|>)"
-              },
-              {
-                  "comment": "comparison operators",
-                  "name": "keyword.operator.comparison.sway",
-                  "match": "(=(=)?(?!>)|!=|<=|(?<!=)>=)"
-              },
-              {
-                  "comment": "math operators",
-                  "name": "keyword.operator.math.sway",
-                  "match": "(([+%]|(\\*(?!\\w)))(?!=))|(-(?!>))|(/(?!/))"
-              },
-              {
-                  "comment": "less than, greater than (special case)",
-                  "match": "(?:\\b|(?:(\\))|(\\])|(\\})))[ \\t]+([<>])[ \\t]+(?:\\b|(?:(\\()|(\\[)|(\\{)))",
-                  "captures": {
-                      "1": {
-                          "name": "punctuation.brackets.round.sway"
-                      },
-                      "2": {
-                          "name": "punctuation.brackets.square.sway"
-                      },
-                      "3": {
-                          "name": "punctuation.brackets.curly.sway"
-                      },
-                      "4": {
-                          "name": "keyword.operator.comparison.sway"
-                      },
-                      "5": {
-                          "name": "punctuation.brackets.round.sway"
-                      },
-                      "6": {
-                          "name": "punctuation.brackets.square.sway"
-                      },
-                      "7": {
-                          "name": "punctuation.brackets.curly.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "namespace operator",
-                  "name": "keyword.operator.namespace.sway",
-                  "match": "::"
-              },
-              {
-                  "comment": "dereference asterisk",
-                  "match": "(\\*)(?=\\w+)",
-                  "captures": {
-                      "1": {
-                          "name": "keyword.operator.dereference.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "subpattern binding",
-                  "name": "keyword.operator.subpattern.sway",
-                  "match": "@"
-              },
-              {
-                  "comment": "dot access",
-                  "name": "keyword.operator.access.dot.sway",
-                  "match": "\\.(?!\\.)"
-              },
-              {
-                  "comment": "ranges, range patterns",
-                  "name": "keyword.operator.range.sway",
-                  "match": "\\.{2}(=|\\.)?"
-              },
-              {
-                  "comment": "colon",
-                  "name": "keyword.operator.key-value.sway",
-                  "match": ":(?!:)"
-              },
-              {
-                  "comment": "dashrocket, skinny arrow",
-                  "name": "keyword.operator.arrow.skinny.sway",
-                  "match": "->"
-              },
-              {
-                  "comment": "hashrocket, fat arrow",
-                  "name": "keyword.operator.arrow.fat.sway",
-                  "match": "=>"
-              },
-              {
-                  "comment": "dollar macros",
-                  "name": "keyword.operator.macro.dollar.sway",
-                  "match": "\\$"
-              },
-              {
-                  "comment": "question mark operator, questionably sized, macro kleene matcher",
-                  "name": "keyword.operator.question.sway",
-                  "match": "\\?"
-              }
-          ]
-      },
-      "interpolations": {
-          "comment": "curly brace interpolations",
-          "name": "meta.interpolation.sway",
-          "match": "({)[^\"{}]*(})",
-          "captures": {
-              "1": {
-                  "name": "punctuation.definition.interpolation.sway"
-              },
-              "2": {
-                  "name": "punctuation.definition.interpolation.sway"
-              }
-          }
-      },
-      "lifetimes": {
-          "patterns": [
-              {
-                  "comment": "named lifetime parameters",
-                  "match": "(['])([a-zA-Z_][0-9a-zA-Z_]*)(?!['])\\b",
-                  "captures": {
-                      "1": {
-                          "name": "punctuation.definition.lifetime.sway"
-                      },
-                      "2": {
-                          "name": "entity.name.type.lifetime.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "borrowing references to named lifetimes",
-                  "match": "(\\&)(['])([a-zA-Z_][0-9a-zA-Z_]*)(?!['])\\b",
-                  "captures": {
-                      "1": {
-                          "name": "keyword.operator.borrow.sway"
-                      },
-                      "2": {
-                          "name": "punctuation.definition.lifetime.sway"
-                      },
-                      "3": {
-                          "name": "entity.name.type.lifetime.sway"
-                      }
-                  }
-              }
-          ]
-      },
-      "macros": {
-          "patterns": [
-              {
-                  "comment": "macros",
-                  "name": "meta.macro.sway",
-                  "match": "(([a-z_][A-Za-z0-9_]*!)|([A-Z_][A-Za-z0-9_]*!))",
-                  "captures": {
-                      "2": {
-                          "name": "entity.name.function.macro.sway"
-                      },
-                      "3": {
-                          "name": "entity.name.type.macro.sway"
-                      }
-                  }
-              }
-          ]
-      },
-      "namespaces": {
-          "patterns": [
-              {
-                  "comment": "namespace (non-type, non-function path segment)",
-                  "match": "(?<![A-Za-z0-9_])([a-z0-9_]+)((?<!super|self)::)",
-                  "captures": {
-                      "1": {
-                          "name": "entity.name.namespace.sway"
-                      },
-                      "2": {
-                          "name": "keyword.operator.namespace.sway"
-                      }
-                  }
-              }
-          ]
-      },
-      "types": {
-          "patterns": [
-              {
-                  "comment": "numeric types",
-                  "match": "(?<![A-Za-z])(f32|f64|i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)\\b",
-                  "captures": {
-                      "1": {
-                          "name": "entity.name.type.numeric.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "parameterized types",
-                  "begin": "\\b([A-Z][A-Za-z0-9]*)(<)",
-                  "beginCaptures": {
-                      "1": {
-                          "name": "entity.name.type.sway"
-                      },
-                      "2": {
-                          "name": "punctuation.brackets.angle.sway"
-                      }
-                  },
-                  "end": ">",
-                  "endCaptures": {
-                      "0": {
-                          "name": "punctuation.brackets.angle.sway"
-                      }
-                  },
-                  "patterns": [
-                      {
-                          "include": "#block-comments"
-                      },
-                      {
-                          "include": "#comments"
-                      },
-                      {
-                          "include": "#keywords"
-                      },
-                      {
-                          "include": "#lvariables"
-                      },
-                      {
-                          "include": "#lifetimes"
-                      },
-                      {
-                          "include": "#punctuation"
-                      },
-                      {
-                          "include": "#types"
-                      },
-                      {
-                          "include": "#variables"
-                      }
-                  ]
-              },
-              {
-                  "comment": "primitive types",
-                  "name": "entity.name.type.primitive.sway",
-                  "match": "\\b(bool|char|str)\\b"
-              },
-              {
-                  "comment": "trait declarations",
-                  "match": "\\b(trait)\\s+([A-Z][A-Za-z0-9]*)\\b",
-                  "captures": {
-                      "1": {
-                          "name": "keyword.declaration.trait.sway storage.type.sway"
-                      },
-                      "2": {
-                          "name": "entity.name.type.trait.sway"
-                      }
-                  }
-              },
-              {
-                "comment": "abi declarations",
-                "match": "\\b(abi)\\s+([A-Z][A-Za-z0-9]*)\\b",
-                "captures": {
-                    "1": {
-                        "name": "keyword.declaration.abi.sway storage.type.sway"
-                    },
-                    "2": {
-                        "name": "entity.name.type.abi.sway"
-                    }
-                }
-              },
-              {
-                  "comment": "struct declarations",
-                  "match": "\\b(struct)\\s+([A-Z][A-Za-z0-9]*)\\b",
-                  "captures": {
-                      "1": {
-                          "name": "keyword.declaration.struct.sway storage.type.sway"
-                      },
-                      "2": {
-                          "name": "entity.name.type.struct.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "enum declarations",
-                  "match": "\\b(enum)\\s+([A-Z][A-Za-z0-9_]*)\\b",
-                  "captures": {
-                      "1": {
-                          "name": "keyword.declaration.enum.sway storage.type.sway"
-                      },
-                      "2": {
-                          "name": "entity.name.type.enum.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "type declarations",
-                  "match": "\\b(type)\\s+([A-Z][A-Za-z0-9_]*)\\b",
-                  "captures": {
-                      "1": {
-                          "name": "keyword.declaration.type.sway storage.type.sway"
-                      },
-                      "2": {
-                          "name": "entity.name.type.declaration.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "types",
-                  "name": "entity.name.type.sway",
-                  "match": "\\b[A-Z][A-Za-z0-9]*\\b(?!!)"
-              },
-              {
-                "comment": "top level declaration",
-                "begin": "\\b(library)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-                "end": "[\\{\\(;]",
-                "beginCaptures": {
-                  "1": {
-                    "name": "storage.type.sway"
-                  },
-                  "2": {
-                    "name": "entity.name.type.sway"
-                  }
-                },
-                "patterns": [
-                  {
-                      "include": "#block-comments"
-                  },
-                  {
-                      "include": "#comments"
-                  },
-                  {
-                      "include": "#keywords"
-                  },
-                  {
-                      "include": "#namespaces"
-                  },
-                  {
-                      "include": "#punctuation"
-                  },
-                  {
-                      "include": "#types"
-                  },
-                  {
-                      "include": "#lvariables"
-                  }
-                ]
-              },
-              {
-                "comment": "top level declaration without name",
-                "match": "(contract|script|predicate);",
-                "captures": {
-                  "1": {
-                    "name": "storage.type.sway"
-                  }
-                }
-              }              
-          ]
-      },
-      "gtypes": {
-          "patterns": [
-              {
-                  "comment": "option types",
-                  "name": "entity.name.type.option.sway",
-                  "match": "\\b(Some|None)\\b"
-              },
-              {
-                  "comment": "result types",
-                  "name": "entity.name.type.result.sway",
-                  "match": "\\b(Ok|Err)\\b"
-              }
-          ]
-      },
-      "punctuation": {
-          "patterns": [
-              {
-                  "comment": "comma",
-                  "name": "punctuation.comma.sway",
-                  "match": ","
-              },
-              {
-                  "comment": "curly braces",
-                  "name": "punctuation.brackets.curly.sway",
-                  "match": "[{}]"
-              },
-              {
-                  "comment": "parentheses, round brackets",
-                  "name": "punctuation.brackets.round.sway",
-                  "match": "[()]"
-              },
-              {
-                  "comment": "semicolon",
-                  "name": "punctuation.semi.sway",
-                  "match": ";"
-              },
-              {
-                  "comment": "square brackets",
-                  "name": "punctuation.brackets.square.sway",
-                  "match": "[\\[\\]]"
-              },
-              {
-                  "comment": "angle brackets",
-                  "name": "punctuation.brackets.angle.sway",
-                  "match": "(?<!=)[<>]"
-              }
-          ]
-      },
-      "strings": {
-          "patterns": [
-              {
-                  "comment": "double-quoted strings and byte strings",
-                  "name": "string.quoted.double.sway",
-                  "begin": "(b?)(\")",
-                  "beginCaptures": {
-                      "1": {
-                          "name": "string.quoted.byte.raw.sway"
-                      },
-                      "2": {
-                          "name": "punctuation.definition.string.sway"
-                      }
-                  },
-                  "end": "\"",
-                  "endCaptures": {
-                      "0": {
-                          "name": "punctuation.definition.string.sway"
-                      }
-                  },
-                  "patterns": [
-                      {
-                          "include": "#escapes"
-                      },
-                      {
-                          "include": "#interpolations"
-                      }
-                  ]
-              },
-              {
-                  "comment": "double-quoted raw strings and raw byte strings",
-                  "name": "string.quoted.double.sway",
-                  "begin": "(b?r)(#*)(\")",
-                  "beginCaptures": {
-                      "1": {
-                          "name": "string.quoted.byte.raw.sway"
-                      },
-                      "2": {
-                          "name": "punctuation.definition.string.raw.sway"
-                      },
-                      "3": {
-                          "name": "punctuation.definition.string.sway"
-                      }
-                  },
-                  "end": "(\")(\\2)",
-                  "endCaptures": {
-                      "1": {
-                          "name": "punctuation.definition.string.sway"
-                      },
-                      "2": {
-                          "name": "punctuation.definition.string.raw.sway"
-                      }
-                  }
-              },
-              {
-                  "comment": "characters and bytes",
-                  "name": "string.quoted.single.char.sway",
-                  "begin": "(b)?(')",
-                  "beginCaptures": {
-                      "1": {
-                          "name": "string.quoted.byte.raw.sway"
-                      },
-                      "2": {
-                          "name": "punctuation.definition.char.sway"
-                      }
-                  },
-                  "end": "'",
-                  "endCaptures": {
-                      "0": {
-                          "name": "punctuation.definition.char.sway"
-                      }
-                  },
-                  "patterns": [
-                      {
-                          "include": "#escapes"
-                      }
-                  ]
-              }
-          ]
-      },
-      "lvariables": {
-          "patterns": [
-              {
-                  "comment": "self",
-                  "name": "variable.language.self.sway",
-                  "match": "\\b[Ss]elf\\b"
-              },
-              {
-                  "comment": "super",
-                  "name": "variable.language.super.sway",
-                  "match": "\\bsuper\\b"
-              }
-          ]
-      },
-      "variables": {
-          "patterns": [
-              {
-                  "comment": "variables",
-                  "name": "variable.other.sway",
-                  "match": "\\b(?<!(?<!\\.)\\.)(?:r#(?!(crate|[Ss]elf|super)))?[a-z0-9_]+\\b"
-              }
-          ]
-      }
+        }
+      ]
+    },
+    "lvariables": {
+      "patterns": [
+        {
+          "comment": "self",
+          "name": "variable.language.self.sway",
+          "match": "\\b[Ss]elf\\b"
+        },
+        {
+          "comment": "super",
+          "name": "variable.language.super.sway",
+          "match": "\\bsuper\\b"
+        }
+      ]
+    },
+    "variables": {
+      "patterns": [
+        {
+          "comment": "variables",
+          "name": "variable.other.sway",
+          "match": "\\b(?<!(?<!\\.)\\.)(?:r#(?!(crate|[Ss]elf|super)))?[a-z0-9_]+\\b"
+        }
+      ]
+    }
   }
 }

--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -1026,7 +1026,52 @@
                   "comment": "types",
                   "name": "entity.name.type.sway",
                   "match": "\\b[A-Z][A-Za-z0-9]*\\b(?!!)"
-              }
+              },
+              {
+                "comment": "top level declaration",
+                "begin": "\\b(library)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+                "end": "[\\{\\(;]",
+                "beginCaptures": {
+                  "1": {
+                    "name": "storage.type.sway"
+                  },
+                  "2": {
+                    "name": "entity.name.type.sway"
+                  }
+                },
+                "patterns": [
+                  {
+                      "include": "#block-comments"
+                  },
+                  {
+                      "include": "#comments"
+                  },
+                  {
+                      "include": "#keywords"
+                  },
+                  {
+                      "include": "#namespaces"
+                  },
+                  {
+                      "include": "#punctuation"
+                  },
+                  {
+                      "include": "#types"
+                  },
+                  {
+                      "include": "#lvariables"
+                  }
+                ]
+              },
+              {
+                "comment": "top level declaration without name",
+                "match": "(contract|script|predicate);",
+                "captures": {
+                  "1": {
+                    "name": "storage.type.sway"
+                  }
+                }
+              }              
           ]
       },
       "gtypes": {

--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -678,6 +678,11 @@
                   "match": "\\b(trait)\\b"
               },
               {
+                "comment": "abi keyword",
+                "name": "keyword.declaration.abi.sway storage.type.sway",
+                "match": "\\b(abi)\\b"
+              },
+              {
                   "comment": "struct keyword",
                   "name": "keyword.declaration.struct.sway storage.type.sway",
                   "match": "\\b(struct)\\b"
@@ -968,6 +973,18 @@
                           "name": "entity.name.type.trait.sway"
                       }
                   }
+              },
+              {
+                "comment": "abi declarations",
+                "match": "\\b(abi)\\s+([A-Z][A-Za-z0-9]*)\\b",
+                "captures": {
+                    "1": {
+                        "name": "keyword.declaration.abi.sway storage.type.sway"
+                    },
+                    "2": {
+                        "name": "entity.name.type.abi.sway"
+                    }
+                }
               },
               {
                   "comment": "struct declarations",

--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -1036,7 +1036,7 @@
           "end": "[\\{\\(;]",
           "beginCaptures": {
             "1": {
-              "name": "storage.type.sway"
+              "name": "source.sway meta.attribute.sway"
             },
             "2": {
               "name": "entity.name.type.sway"
@@ -1071,7 +1071,7 @@
           "match": "(contract|script|predicate);",
           "captures": {
             "1": {
-              "name": "storage.type.sway"
+              "name": "source.sway meta.attribute.sway"
             }
           }
         }

--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -45,76 +45,6 @@
       ]
     },
     {
-      "comment": "macro type metavariables",
-      "name": "meta.macro.metavariable.type.sway",
-      "match": "(\\$)((crate)|([A-Z][A-Za-z0-9_]*))((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?",
-      "captures": {
-        "1": {
-          "name": "keyword.operator.macro.dollar.sway"
-        },
-        "3": {
-          "name": "keyword.other.crate.sway"
-        },
-        "4": {
-          "name": "entity.name.type.metavariable.sway"
-        },
-        "6": {
-          "name": "keyword.operator.key-value.sway"
-        },
-        "7": {
-          "name": "variable.other.metavariable.specifier.sway"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#keywords"
-        }
-      ]
-    },
-    {
-      "comment": "macro metavariables",
-      "name": "meta.macro.metavariable.sway",
-      "match": "(\\$)([a-z][A-Za-z0-9_]*)((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?",
-      "captures": {
-        "1": {
-          "name": "keyword.operator.macro.dollar.sway"
-        },
-        "2": {
-          "name": "variable.other.metavariable.name.sway"
-        },
-        "4": {
-          "name": "keyword.operator.key-value.sway"
-        },
-        "5": {
-          "name": "variable.other.metavariable.specifier.sway"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#keywords"
-        }
-      ]
-    },
-    {
-      "comment": "macro rules",
-      "name": "meta.macro.rules.sway",
-      "match": "\\b(macro_rules!)\\s+(([a-z0-9_]+)|([A-Z][a-z0-9_]*))\\s+(\\{)",
-      "captures": {
-        "1": {
-          "name": "entity.name.function.macro.rules.sway"
-        },
-        "3": {
-          "name": "entity.name.function.macro.sway"
-        },
-        "4": {
-          "name": "entity.name.type.macro.sway"
-        },
-        "5": {
-          "name": "punctuation.brackets.curly.sway"
-        }
-      }
-    },
-    {
       "comment": "attributes",
       "name": "meta.attribute.sway",
       "begin": "(#)(\\!?)(\\[)",
@@ -450,6 +380,69 @@
           }
         },
         {
+          "comment": "assembly block",
+          "name": "meta.asm.definition.sway",
+          "begin": "\\b(asm)((\\())",
+          "beginCaptures": {
+            "1": {
+              "name": "meta.attribute.asm.sway"
+            },
+            "2": {
+              "name": "punctuation.brackets.round.sway"
+            }
+          },
+          "end": "\\{|;",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.curly.sway"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#gtypes"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#lifetimes"
+            },
+            {
+              "include": "#macros"
+            },
+            {
+              "include": "#namespaces"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
           "comment": "function definition",
           "name": "meta.function.definition.sway",
           "begin": "\\b(fn)\\s+((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)((\\()|(<))",
@@ -704,6 +697,11 @@
           "comment": "fn",
           "name": "keyword.other.fn.sway",
           "match": "\\bfn\\b"
+        },
+        {
+          "comment": "asm",
+          "name": "meta.attribute.asm.sway",
+          "match": "\\basm\\b"
         },
         {
           "comment": "crate",


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway-vscode-plugin/issues/72

This is making sway's tmLanguage grammar nearly identical to the [rust grammar](https://raw.githubusercontent.com/dustypomerleau/rust-syntax/master/syntaxes/rust.tmLanguage.json).

The differences I added for sway are:
- `abi` is a special keyword
- `mod` in rust -> `dep` in sway
- `predicate`, `library`, `script`, and `contract` match the `#[]` highlighting in rust ("meta attribute")
- `asm` is highlighted as a meta attribute

Left: this branch, Right: master
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/47993817/184286907-c3f8d383-d09d-4bf2-80b9-66d94a52dbb7.png">

Left: sway, Right: rust, Theme: Pale Fire Dark
<img width="1204" alt="image" src="https://user-images.githubusercontent.com/47993817/184286389-2accc4ba-5d03-4f86-abdb-7b3bd1eb4290.png">

Left: sway, Right: rust, Theme: Dark+
<img width="1201" alt="image" src="https://user-images.githubusercontent.com/47993817/184286476-34d694cd-fcdb-4eb2-a1d5-b83e9780b6e1.png">

asm keyword:
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/47993817/184294095-b991aeac-3f50-4ccb-9cc3-3ff9e750a1ee.png">
