### PR TITLE
Separate format CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16
+      - run: npm ci
       - run: npm run format:check
 
   build:
@@ -25,7 +26,6 @@ jobs:
           node-version: 16
 
       - run: npm ci
-
       - name: Dry run publish
         uses: HaaLeo/publish-vscode-extension@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,22 +6,28 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  format:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - run: npm run format:check
 
+  build:
+    needs: [format]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 16
 
       - run: npm ci
 
-      - run: npm run format:check
-
       - name: Dry run publish
         uses: HaaLeo/publish-vscode-extension@v1
         with:
-          pat: "quickbrownfox"
+          pat: 'quickbrownfox'
           dryRun: true


### PR DESCRIPTION
Separates the `format:check` step from the build step in CI. This makes it easier to see what failed on a PR.