### PR TITLE
Change show collected tokens as warnings into a drop down menu

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -93,8 +93,8 @@ export class Config {
 
   get debug() {
     return {
-      showParsedTokensAsWarnings: this.get<boolean>(
-        'debug.showParsedTokensAsWarnings'
+      showCollectedTokensAsWarnings: this.get<string>(
+        'debug.showCollectedTokensAsWarnings'
       ),
     };
   }

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -93,7 +93,7 @@ export class Config {
 
   get debug() {
     return {
-      showCollectedTokensAsWarnings: this.get<string>(
+      showCollectedTokensAsWarnings: this.get<'off' | 'parsed' | 'typed'>(
         'debug.showCollectedTokensAsWarnings'
       ),
     };

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -99,8 +99,10 @@ function getServerOptions(
   config: Config
 ): lc.ServerOptions {
   let args = ['lsp'];
-  if (config.debug.showParsedTokensAsWarnings) {
-    args.push(' --parsed-tokens-as-warnings');
+  let debug_tokens = config.debug.showCollectedTokensAsWarnings;
+  if (debug_tokens != "off") {
+    args.push(' --collected-tokens-as-warnings ');
+    args.push(debug_tokens);
   }
 
   const serverExecutable: lc.Executable = {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -100,7 +100,7 @@ function getServerOptions(
 ): lc.ServerOptions {
   let args = ['lsp'];
   let debug_tokens = config.debug.showCollectedTokensAsWarnings;
-  if (debug_tokens != "off") {
+  if (debug_tokens != 'off') {
     args.push(' --collected-tokens-as-warnings ');
     args.push(debug_tokens);
   }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -99,10 +99,9 @@ function getServerOptions(
   config: Config
 ): lc.ServerOptions {
   let args = ['lsp'];
-  let debug_tokens = config.debug.showCollectedTokensAsWarnings;
-  if (debug_tokens != 'off') {
-    args.push(' --collected-tokens-as-warnings ');
-    args.push(debug_tokens);
+  const debug_tokens = config.debug.showCollectedTokensAsWarnings;
+  if (debug_tokens !== 'off') {
+    args.push(` --collected-tokens-as-warnings ${debug_tokens}`);
   }
 
   const serverExecutable: lc.Executable = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sway-vscode-plugin",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -132,10 +132,21 @@
           "type": "boolean",
           "default": false
         },
-        "sway-lsp.debug.showParsedTokensAsWarnings": {
-          "markdownDescription": "Show successfully parsed tokens by the sway-lsp server as warnings. If set to false, sway-lsp will revert to only showing warnings and errors reported by the compiler.",
-          "default": false,
-          "type": "boolean"
+        "sway-lsp.debug.showCollectedTokensAsWarnings": {
+          "scope": "window",
+          "type": "string",
+          "description": "Show either successfully parsed or typed tokens by the sway-lsp server as warnings. If set to off, sway-lsp will revert to only showing warnings and errors reported by the compiler.",
+          "enum": [
+            "off",
+            "parsed",
+            "typed"
+          ],
+          "enumDescriptions": [
+            "Debugging off",
+            "Show parsed tokens",
+            "Show typed tokens"
+          ],
+          "default": "off"
         },
         "sway-lsp.trace.fuel-core.logfile": {
           "description": "Set the file path for the Fuel core log output.",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Sway",
   "description": "Sway language extension for Visual Studio Code",
   "icon": "images/logo.png",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "FuelLabs",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR changes the show collected tokens as warnings option into a drop-down menu so we can switch easily back and forth between seeing the parsed or the typed tokens that have been collected in the language server. 