### PR TITLE
Start fuel-core with in-memory db

### DIFF
--- a/client/src/commands/startFuelCore.ts
+++ b/client/src/commands/startFuelCore.ts
@@ -4,7 +4,7 @@ import { Config } from '../config';
 
 export default function startFuelCore(config: Config) {
   const fuelCoreLogFile = config.traceFuelCoreLogFile;
-  exec(`fuel-core > ${fuelCoreLogFile} 2>&1 &`, () => {
+  exec(`fuel-core --db-type in-memory > ${fuelCoreLogFile} 2>&1 &`, () => {
     window.showInformationMessage(
       `Started Fuel Core in the background. Logs at ${fuelCoreLogFile}`
     );


### PR DESCRIPTION
Using the `fuel-core --db-type in-memory` option makes sure that when restarting fuel-core, there's no state persisted between sessions, e.g. past transactions or deployed contracts that would fail to run a second time. 