### PR TITLE
Add command palettes to show AST files

### DIFF
--- a/client/src/commands/openAstFile.ts
+++ b/client/src/commands/openAstFile.ts
@@ -1,24 +1,24 @@
-import { Uri, window, workspace } from 'vscode';
+import { commands, Uri } from 'vscode';
 import { AstKind, showAst } from '../interface/showAst';
 import { log } from '../util';
 
+const addFilePrefix = (path: string) => `file:///${path}`;
+
 export default async function openAstFile(filePath: string, astKind: AstKind) {
   try {
-    const astDocument = await showAst(filePath, astKind);
+    const astDocument = await showAst(addFilePrefix(filePath), astKind);
     if (astDocument) {
-      const openPath = Uri.parse('file:///' + astDocument.uri);
-      workspace
-        .openTextDocument(openPath)
-        .then(doc => {
-          window.showTextDocument(doc);
-        })
-        .then(() => log.info(`Successfully opened AST file ${filePath}`));
+      const openPath = Uri.parse(astDocument.uri);
+      await commands.executeCommand('vscode.openFolder', openPath, {
+        forceNewWindow: true,
+      });
+      log.info(`Successfully opened ${astKind} AST file ${filePath}`);
     } else {
       log.error(`No ${astKind} AST file found for ${filePath}`);
     }
   } catch (error) {
     log.error(
-      `An error occurred while attempting to open ${astKind} AST file found for ${filePath}`,
+      `Failed to open ${astKind} AST file found for ${filePath}`,
       error
     );
   }

--- a/client/src/commands/openAstFile.ts
+++ b/client/src/commands/openAstFile.ts
@@ -6,16 +6,20 @@ export default async function openAstFile(filePath: string, astKind: AstKind) {
   try {
     const astDocument = await showAst(filePath, astKind);
     if (astDocument) {
-      const openPath = Uri.parse("file:///" + astDocument.uri);
-      workspace.openTextDocument(openPath)
-      .then(doc => {
-        window.showTextDocument(doc);
-      })
-      .then(() => log.info(`Successfully opened AST file ${filePath}`));
+      const openPath = Uri.parse('file:///' + astDocument.uri);
+      workspace
+        .openTextDocument(openPath)
+        .then(doc => {
+          window.showTextDocument(doc);
+        })
+        .then(() => log.info(`Successfully opened AST file ${filePath}`));
     } else {
       log.error(`No ${astKind} AST file found for ${filePath}`);
     }
-  } catch(error) {
-    log.error(`An error occurred while attempting to open ${astKind} AST file found for ${filePath}`, error);
+  } catch (error) {
+    log.error(
+      `An error occurred while attempting to open ${astKind} AST file found for ${filePath}`,
+      error
+    );
   }
 }

--- a/client/src/commands/openAstFile.ts
+++ b/client/src/commands/openAstFile.ts
@@ -2,7 +2,7 @@ import { commands, Uri } from 'vscode';
 import { AstKind, showAst } from '../interface/showAst';
 import { log } from '../util';
 
-const addFilePrefix = (path: string) => `file:///${path}`;
+const addFilePrefix = (path: string) => `file://${path}`;
 
 export default async function openAstFile(filePath: string, astKind: AstKind) {
   try {

--- a/client/src/commands/openAstFile.ts
+++ b/client/src/commands/openAstFile.ts
@@ -1,0 +1,21 @@
+import { Uri, window, workspace } from 'vscode';
+import { AstKind, showAst } from '../interface/showAst';
+import { log } from '../util';
+
+export default async function openAstFile(filePath: string, astKind: AstKind) {
+  try {
+    const astDocument = await showAst(filePath, astKind);
+    if (astDocument) {
+      const openPath = Uri.parse("file:///" + astDocument.uri);
+      workspace.openTextDocument(openPath)
+      .then(doc => {
+        window.showTextDocument(doc);
+      })
+      .then(() => log.info(`Successfully opened AST file ${filePath}`));
+    } else {
+      log.error(`No ${astKind} AST file found for ${filePath}`);
+    }
+  } catch(error) {
+    log.error(`An error occurred while attempting to open ${astKind} AST file found for ${filePath}`, error);
+  }
+}

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { AstKind } from './interface/showAst';
 import { log } from './util';
 
 export class Config {
@@ -93,7 +94,7 @@ export class Config {
 
   get debug() {
     return {
-      showCollectedTokensAsWarnings: this.get<'off' | 'parsed' | 'typed'>(
+      showCollectedTokensAsWarnings: this.get<'off' | AstKind>(
         'debug.showCollectedTokensAsWarnings'
       ),
     };

--- a/client/src/interface/getRunnables.ts
+++ b/client/src/interface/getRunnables.ts
@@ -1,7 +1,6 @@
 import { RequestType } from 'vscode-languageclient/node';
 import { getClient } from '../client';
 import { Range } from 'vscode';
-import { log } from '../util';
 import { ProgramType } from '../program';
 
 interface GetRunnablesParams {}

--- a/client/src/interface/showAst.ts
+++ b/client/src/interface/showAst.ts
@@ -1,4 +1,7 @@
-import { RequestType, TextDocumentIdentifier } from 'vscode-languageclient/node';
+import {
+  RequestType,
+  TextDocumentIdentifier,
+} from 'vscode-languageclient/node';
 import { getClient } from '../client';
 import { Range } from 'vscode';
 import { log } from '../util';
@@ -10,17 +13,22 @@ interface ShowAstParams {
   astKind: AstKind;
 }
 
-const request = new RequestType<ShowAstParams, TextDocumentIdentifier | null, void>(
-  'sway/show_ast'
-);
+const request = new RequestType<
+  ShowAstParams,
+  TextDocumentIdentifier | null,
+  void
+>('sway/show_ast');
 
-export const showAst = async (filePath: string, astKind: AstKind): Promise<TextDocumentIdentifier | null> => {
+export const showAst = async (
+  filePath: string,
+  astKind: AstKind
+): Promise<TextDocumentIdentifier | null> => {
   const client = getClient();
   const params: ShowAstParams = {
     textDocument: {
-      uri: filePath
+      uri: filePath,
     },
-    astKind
+    astKind,
   };
   log.info(`params`, params);
   const response = await client.sendRequest(request, params);
@@ -28,5 +36,3 @@ export const showAst = async (filePath: string, astKind: AstKind): Promise<TextD
 
   return response;
 };
-
-

--- a/client/src/interface/showAst.ts
+++ b/client/src/interface/showAst.ts
@@ -1,0 +1,32 @@
+import { RequestType, TextDocumentIdentifier } from 'vscode-languageclient/node';
+import { getClient } from '../client';
+import { Range } from 'vscode';
+import { log } from '../util';
+
+export type AstKind = 'parsed' | 'typed';
+
+interface ShowAstParams {
+  textDocument: TextDocumentIdentifier;
+  astKind: AstKind;
+}
+
+const request = new RequestType<ShowAstParams, TextDocumentIdentifier | null, void>(
+  'sway/show_ast'
+);
+
+export const showAst = async (filePath: string, astKind: AstKind): Promise<TextDocumentIdentifier | null> => {
+  const client = getClient();
+  const params: ShowAstParams = {
+    textDocument: {
+      uri: filePath
+    },
+    astKind
+  };
+  log.info(`params`, params);
+  const response = await client.sendRequest(request, params);
+  log.info(`response`, response);
+
+  return response;
+};
+
+

--- a/client/src/interface/showAst.ts
+++ b/client/src/interface/showAst.ts
@@ -30,9 +30,5 @@ export const showAst = async (
     },
     astKind,
   };
-  log.info(`params`, params);
-  const response = await client.sendRequest(request, params);
-  log.info(`response`, response);
-
-  return response;
+  return await client.sendRequest(request, params);
 };

--- a/client/src/interface/showAst.ts
+++ b/client/src/interface/showAst.ts
@@ -3,8 +3,6 @@ import {
   TextDocumentIdentifier,
 } from 'vscode-languageclient/node';
 import { getClient } from '../client';
-import { Range } from 'vscode';
-import { log } from '../util';
 
 export type AstKind = 'parsed' | 'typed';
 

--- a/client/src/palettes.ts
+++ b/client/src/palettes.ts
@@ -5,6 +5,7 @@ import { Config } from './config';
 import forcRun from './commands/forcRun';
 import startFuelCore from './commands//startFuelCore';
 import forcBuild from './commands/forcBuild';
+import openAstFile from './commands/openAstFile';
 
 interface CommandPalette {
   command: string;
@@ -19,7 +20,7 @@ export class CommandPalettes {
       {
         command: 'sway.runScript',
         callback: async () => {
-          var currentTabDirectory = path.dirname(
+          const currentTabDirectory = path.dirname(
             vscode.window.activeTextEditor.document.fileName
           );
           forcRun(currentTabDirectory);
@@ -28,7 +29,7 @@ export class CommandPalettes {
       {
         command: 'sway.forcBuild',
         callback: async () => {
-          var currentTabDirectory = path.dirname(
+          const currentTabDirectory = path.dirname(
             vscode.window.activeTextEditor.document.fileName
           );
           forcBuild(currentTabDirectory);
@@ -38,6 +39,20 @@ export class CommandPalettes {
         command: 'sway.startFuelCore',
         callback: async () => {
           startFuelCore(this.config);
+        },
+      },
+      {
+        command: 'sway.showParsedAst',
+        callback: async () => {
+          const currentFile = vscode.window.activeTextEditor.document.fileName;
+          await openAstFile(currentFile, 'parsed');
+        },
+      },
+      {
+        command: 'sway.showTypedAst',
+        callback: async () => {
+          const currentFile = vscode.window.activeTextEditor.document.fileName;
+          await openAstFile(currentFile, 'typed');
         },
       },
     ];

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "onCommand:sway.runScript",
     "onCommand:sway.forcBuild",
     "onCommand:sway.startFuelCore",
+    "onCommand:sway.showParsedAst",
+    "onCommand:sway.showTypedAst",
     "onCommand:programs.refreshEntry",
     "onCommand:programs.editEntry",
     "onCommand:programs.run"
@@ -167,7 +169,15 @@
         {
           "command": "sway.startFuelCore",
           "title": "Sway: Start Fuel Core"
-        }
+        },
+        {
+          "command": "sway.showParsedAst",
+          "title": "Sway: Show Parsed AST"
+        },
+        {
+          "command": "sway.showTypedAst",
+          "title": "Sway: Show Typed AST"
+        }  
       ]
     },
     "languages": [
@@ -219,6 +229,14 @@
       {
         "command": "sway.startFuelCore",
         "title": "Sway: Start Fuel Core"
+      },
+      {
+        "command": "sway.showParsedAst",
+        "title": "Sway: Show Parsed AST"
+      },
+      {
+        "command": "sway.showTypedAst",
+        "title": "Sway: Show Typed AST"
       }
     ],
     "snippets": [


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway-vscode-plugin/issues/84

- adds 2 new command palettes
- opens the AST file in a new window