### PR TITLE
remove old formatting options

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -148,58 +148,7 @@ function getClientOptions(): lc.LanguageClientOptions {
         workspace.createFileSystemWatcher('**/*.sw'),
       ],
     },
-    initializationOptions: {
-      ...getSwayConfigOptions(),
-    },
   };
 
   return clientOptions;
 }
-
-function getSwayConfigOptions(): SwayConfig {
-  const swayOptions = getSwayFormattingOptions();
-
-  const defaultSwayConfig: SwayConfig = {
-    alignFields: true,
-    tabSize: 4,
-  };
-
-  if (swayOptions) {
-    const swayFormatOptions = getSwayFormattingOptions().format;
-    if (swayFormatOptions) {
-      return {
-        alignFields: swayFormatOptions.hasOwnProperty('alignFields')
-          ? swayFormatOptions.alignFields
-          : defaultSwayConfig.alignFields,
-        tabSize: swayFormatOptions.hasOwnProperty('tabSize')
-          ? swayFormatOptions.tabSize
-          : defaultSwayConfig.tabSize,
-      };
-    } else {
-      return defaultSwayConfig;
-    }
-  } else {
-    return defaultSwayConfig;
-  }
-}
-
-function getSwayFormattingOptions(): WorkspaceConfiguration | null {
-  const swayOptions = workspace.getConfiguration('sway');
-  const swayOptionsBracket = workspace.getConfiguration('[sway]');
-
-  if (swayOptions && swayOptions.format) {
-    if (swayOptionsBracket && swayOptionsBracket.format) {
-      return Object.assign({}, swayOptions, swayOptionsBracket);
-    }
-    return swayOptions;
-  } else if (swayOptionsBracket && swayOptionsBracket.format) {
-    return swayOptionsBracket;
-  } else {
-    return null;
-  }
-}
-
-type SwayConfig = {
-  alignFields: boolean;
-  tabSize: number;
-};


### PR DESCRIPTION
Now that the new formatter has landed, we no longer need to have configuration options sent from the client to the server. The PR below in the sway repo handles loading the configuration.

https://github.com/FuelLabs/sway/pull/2801