### PR TITLE
Remove fuel sidebar temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,15 +45,6 @@
     "onCommand:programs.run"
   ],
   "contributes": {
-    "viewsContainers": {
-      "activitybar": [
-        {
-          "id": "sway",
-          "title": "Sway",
-          "icon": "images/fuel.svg"
-        }
-      ]
-    },
     "views": {
       "sway": [
         {


### PR DESCRIPTION
Temporarily remove the fuel sidebar until workspaces is fully supported.