### PR TITLE
Add `TextDocumentIdentifier` to `GetRunnablesParams`

### DIFF
--- a/client/src/code_lens/provider.ts
+++ b/client/src/code_lens/provider.ts
@@ -2,8 +2,8 @@ import { CodeLens, CodeLensProvider, Command, TextDocument } from 'vscode';
 import { getRunnables, Runnable } from '../interface/getRunnables';
 
 export class SwayCodeLensProvider implements CodeLensProvider {
-  async provideCodeLenses(_document: TextDocument): Promise<CodeLens[]> {
-    const runnables: Runnable[] = await getRunnables();
+  async provideCodeLenses(document: TextDocument): Promise<CodeLens[]> {
+    const runnables: Runnable[] = await getRunnables(document.fileName);
     const forcRun: Command = {
       command: 'sway.runScript',
       title: '▶\u{fe0e} Run',

--- a/client/src/commands/openAstFile.ts
+++ b/client/src/commands/openAstFile.ts
@@ -1,8 +1,6 @@
 import { commands, Uri } from 'vscode';
 import { AstKind, showAst } from '../interface/showAst';
-import { log } from '../util';
-
-const addFilePrefix = (path: string) => `file://${path}`;
+import { log, addFilePrefix } from '../util';
 
 export default async function openAstFile(filePath: string, astKind: AstKind) {
   try {

--- a/client/src/interface/getRunnables.ts
+++ b/client/src/interface/getRunnables.ts
@@ -1,9 +1,15 @@
-import { RequestType } from 'vscode-languageclient/node';
+import {
+  RequestType,
+  TextDocumentIdentifier,
+} from 'vscode-languageclient/node';
 import { getClient } from '../client';
 import { Range } from 'vscode';
 import { ProgramType } from '../program';
+import { addFilePrefix } from '../util';
 
-interface GetRunnablesParams {}
+interface GetRunnablesParams {
+  textDocument: TextDocumentIdentifier;
+}
 
 export type Runnable = [Range, ProgramType];
 
@@ -11,9 +17,13 @@ const request = new RequestType<GetRunnablesParams, Runnable[], void>(
   'sway/runnables'
 );
 
-export const getRunnables = async (): Promise<Runnable[]> => {
+export const getRunnables = async (filePath: string): Promise<Runnable[]> => {
   const client = getClient();
-  const params: GetRunnablesParams = {};
+  const params: GetRunnablesParams = {
+    textDocument: {
+      uri: addFilePrefix(filePath),
+    },
+  };
   const response = await client.sendRequest(request, params);
   return response ?? [];
 };

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import { inspect } from 'util';
 
+export const addFilePrefix = (path: string) => `file://${path}`;
+
 export const log = new (class {
   private enabled = true;
   private readonly output =


### PR DESCRIPTION
We need to send info about the file that is requesting the runnables in order to support multiple projects in the server. This is being done in https://github.com/FuelLabs/sway/pull/3072