### PR TITLE
Add a show lexed AST command

### DIFF
--- a/client/src/interface/showAst.ts
+++ b/client/src/interface/showAst.ts
@@ -4,7 +4,7 @@ import {
 } from 'vscode-languageclient/node';
 import { getClient } from '../client';
 
-export type AstKind = 'parsed' | 'typed';
+export type AstKind = 'lexed' | 'parsed' | 'typed';
 
 interface ShowAstParams {
   textDocument: TextDocumentIdentifier;

--- a/client/src/palettes.ts
+++ b/client/src/palettes.ts
@@ -46,6 +46,13 @@ export class CommandPalettes {
         callback: async () => stopFuelCore(),
       },
       {
+        command: 'sway.showLexedAst',
+        callback: async () => {
+          const currentFile = vscode.window.activeTextEditor.document.fileName;
+          await openAstFile(currentFile, 'lexed');
+        },
+      },
+      {
         command: 'sway.showParsedAst',
         callback: async () => {
           const currentFile = vscode.window.activeTextEditor.document.fileName;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "onCommand:sway.forcBuild",
     "onCommand:sway.startFuelCore",
     "onCommand:sway.stopFuelCore",
+    "onCommand:sway.showLexedAst",
     "onCommand:sway.showParsedAst",
     "onCommand:sway.showTypedAst"
   ],
@@ -140,6 +141,10 @@
           "title": "Sway: Stop Fuel Core"
         },
         {
+          "command": "sway.showLexedAst",
+          "title": "Sway: Show Lexed AST"
+        },
+        {
           "command": "sway.showParsedAst",
           "title": "Sway: Show Parsed AST"
         },
@@ -202,6 +207,10 @@
       {
         "command": "sway.stopFuelCore",
         "title": "Sway: Stop Fuel Core"
+      },
+      {
+        "command": "sway.showLexedAst",
+        "title": "Sway: Show Lexed AST"
       },
       {
         "command": "sway.showParsedAst",


### PR DESCRIPTION
This adds a "Sway: Show Lexed AST" command to the command palette. This compliments the existing commands for showing the parsed and typed ASTs. 

Here is the PR in the sway repo that adds this functionality to the language server. https://github.com/FuelLabs/sway/pull/3726