### PR TITLE
Add config option to hide warnings and errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,16 @@
           ],
           "default": "off"
         },
+        "sway-lsp.diagnostic.showWarnings": {
+          "description": "Show compiler warnings",
+          "type": "boolean",
+          "default": true
+        },
+        "sway-lsp.diagnostic.showErrors": {
+          "description": "Show compiler errors",
+          "type": "boolean",
+          "default": true
+        },
         "sway-lsp.logging.level": {
           "scope": "window",
           "type": "string",


### PR DESCRIPTION
Related https://github.com/FuelLabs/sway/pull/3749

Give users the option to show/hide compiler errors and warnings.

![image](https://user-images.githubusercontent.com/47993817/211686713-9f306b19-6186-46fc-b0a0-7cd378b65575.png)
