### PR TITLE
Add command for running tests

### DIFF
--- a/client/src/commands/forcBuild.ts
+++ b/client/src/commands/forcBuild.ts
@@ -1,15 +1,5 @@
-import { exec } from 'child_process';
-import { window } from 'vscode';
 import { log } from '../util';
 
 export default function forcBuild(forcDir: string) {
-  exec(`cd ${forcDir} && forc build`, (error, stdout, _stderr) => {
-    if (error) {
-      window.showInformationMessage(`Failed: see output console for error`);
-      log.error(stdout);
-    } else {
-      window.showInformationMessage(`Successfully built sway program`);
-      log.info(stdout);
-    }
-  });
+  log.terminal(`cd ${forcDir} && forc build`);
 }

--- a/client/src/commands/forcRun.ts
+++ b/client/src/commands/forcRun.ts
@@ -1,15 +1,5 @@
-import { exec } from 'child_process';
-import { window } from 'vscode';
 import { log } from '../util';
 
 export default function forcRun(forcDir: string) {
-  exec(`cd ${forcDir} && forc run --unsigned`, (error, stdout, stderr) => {
-    if (error) {
-      window.showInformationMessage(`Failed: see output console for error`);
-      log.error(stderr);
-    } else {
-      window.showInformationMessage(`Successfully ran script`);
-      log.info(stdout);
-    }
-  });
+  log.terminal(`cd ${forcDir} && forc run --unsigned`);
 }

--- a/client/src/commands/forcTest.ts
+++ b/client/src/commands/forcTest.ts
@@ -1,7 +1,7 @@
 import { log } from '../util';
 
 export default function forcTest(forcDir: string, _testName?: string) {
-  // TODO: add support for running specific tests when 
+  // TODO: add support for running specific tests when
   // https://github.com/FuelLabs/sway/issues/3268 is resolved
   log.terminal(`cd ${forcDir} && forc test`);
 }

--- a/client/src/commands/forcTest.ts
+++ b/client/src/commands/forcTest.ts
@@ -1,0 +1,7 @@
+import { log } from '../util';
+
+export default function forcTest(forcDir: string, _testName?: string) {
+  // TODO: add support for running specific tests when 
+  // https://github.com/FuelLabs/sway/issues/3268 is resolved
+  log.terminal(`cd ${forcDir} && forc test`);
+}

--- a/client/src/palettes.ts
+++ b/client/src/palettes.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { Config } from './config';
 import forcRun from './commands/forcRun';
+import forcTest from './commands/forcTest';
 import startFuelCore from './commands/startFuelCore';
 import forcBuild from './commands/forcBuild';
 import stopFuelCore from './commands/stopFuelCore';
@@ -9,7 +10,7 @@ import openAstFile from './commands/openAstFile';
 
 interface CommandPalette {
   command: string;
-  callback: () => Promise<void>;
+  callback: (args?: any) => Promise<void>;
 }
 
 export class CommandPalettes {
@@ -24,6 +25,15 @@ export class CommandPalettes {
             vscode.window.activeTextEditor.document.fileName
           );
           forcRun(currentTabDirectory);
+        },
+      },
+      {
+        command: 'sway.runTests',
+        callback: async ({ name }: { name?: string }) => {
+          const currentTabDirectory = path.dirname(
+            vscode.window.activeTextEditor.document.fileName
+          );
+          forcTest(currentTabDirectory, name);
         },
       },
       {

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -31,6 +31,21 @@ export const log = new (class {
     log.output.show(true);
   }
 
+  terminal(msg: string): void {
+    const terminal = log.getTerminal();
+    terminal.sendText(msg);
+    terminal.show(true);
+  }
+
+  private getTerminal(): vscode.Terminal {
+    const name = "sway";
+    const terminals = vscode.window.terminals;
+    if (terminals.length === 0) {
+      return vscode.window.createTerminal(name);
+    }
+    return terminals.find(t => t.name == name) ?? terminals[0];
+  }
+
   private write(label: string, ...messageParts: unknown[]): void {
     const message = messageParts.map(log.stringify).join(' ');
     const dateTime = new Date().toLocaleString();

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -38,7 +38,7 @@ export const log = new (class {
   }
 
   private getTerminal(): vscode.Terminal {
-    const name = "sway";
+    const name = 'sway';
     const terminals = vscode.window.terminals;
     if (terminals.length === 0) {
       return vscode.window.createTerminal(name);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "onLanguage:sway",
     "onView:sway",
     "onCommand:sway.runScript",
+    "onCommand:sway.runTests",
     "onCommand:sway.forcBuild",
     "onCommand:sway.startFuelCore",
     "onCommand:sway.stopFuelCore",
@@ -139,6 +140,10 @@
           "title": "Sway: Run script"
         },
         {
+          "command": "sway.runTests",
+          "title": "Sway: Run tests"
+        },
+        {
           "command": "sway.forcBuild",
           "title": "Sway: Build"
         },
@@ -205,6 +210,10 @@
       {
         "command": "sway.runScript",
         "title": "Sway: Run script"
+      },
+      {
+        "command": "sway.runTests",
+        "title": "Sway: Run tests"
       },
       {
         "command": "sway.forcBuild",


### PR DESCRIPTION
Related https://github.com/FuelLabs/sway/issues/3320

Adds a command for running 1 or many tests in the open sway file.
Also updates the logging to print to the terminal instead of the output log. This preserves forc's formatting and looks way better! Updated this everywhere that we're running forc CLI commands.

Currently this runs all of the tests in the file, but once https://github.com/FuelLabs/sway/issues/3268 is ready, it will be an easy thing to update it to run only the 1 test.

![Jan-20-2023 18-04-56](https://user-images.githubusercontent.com/47993817/213838101-27bd42c6-9942-434a-abc5-f63e4cb3aab2.gif)

We should release this change before releasing the backend changes, otherwise the run button will show up but won't work.