### PR TITLE
Trigger publish only after generating changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-name: Generate changelog
+name: Generate Changelog
 on:
   release:
     types: [created, edited]

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -1,8 +1,10 @@
 name: Publish Extension
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ['Generate Changelog']
+    types:
+      - completed
 
 jobs:
   build:


### PR DESCRIPTION
This will ensure the changelog is updated before publishing to the marketplace.