### PR TITLE
Set savePath for show AST commands to tmp dir

### DIFF
--- a/client/src/commands/openAstFile.ts
+++ b/client/src/commands/openAstFile.ts
@@ -4,7 +4,8 @@ import { addFilePrefix, log } from '../util';
 
 export default async function openAstFile(filePath: string, astKind: AstKind) {
   try {
-    const astDocument = await showAst(addFilePrefix(filePath), astKind);
+    let savePath = '/tmp/';
+    const astDocument = await showAst(addFilePrefix(filePath), astKind, addFilePrefix(savePath));
     if (astDocument) {
       const openPath = Uri.parse(astDocument.uri);
       await commands.executeCommand('vscode.openFolder', openPath, {

--- a/client/src/commands/openAstFile.ts
+++ b/client/src/commands/openAstFile.ts
@@ -5,7 +5,11 @@ import { addFilePrefix, log } from '../util';
 export default async function openAstFile(filePath: string, astKind: AstKind) {
   try {
     let savePath = '/tmp/';
-    const astDocument = await showAst(addFilePrefix(filePath), astKind, addFilePrefix(savePath));
+    const astDocument = await showAst(
+      addFilePrefix(filePath),
+      astKind,
+      addFilePrefix(savePath)
+    );
     if (astDocument) {
       const openPath = Uri.parse(astDocument.uri);
       await commands.executeCommand('vscode.openFolder', openPath, {

--- a/client/src/interface/showAst.ts
+++ b/client/src/interface/showAst.ts
@@ -22,7 +22,7 @@ const request = new RequestType<
 export const showAst = async (
   filePath: string,
   astKind: AstKind,
-  savePath: string,
+  savePath: string
 ): Promise<TextDocumentIdentifier | null> => {
   const client = getClient();
   const params: ShowAstParams = {

--- a/client/src/interface/showAst.ts
+++ b/client/src/interface/showAst.ts
@@ -1,4 +1,5 @@
 import {
+  DocumentUri,
   RequestType,
   TextDocumentIdentifier,
 } from 'vscode-languageclient/node';
@@ -9,6 +10,7 @@ export type AstKind = 'lexed' | 'parsed' | 'typed';
 interface ShowAstParams {
   textDocument: TextDocumentIdentifier;
   astKind: AstKind;
+  savePath: DocumentUri;
 }
 
 const request = new RequestType<
@@ -19,7 +21,8 @@ const request = new RequestType<
 
 export const showAst = async (
   filePath: string,
-  astKind: AstKind
+  astKind: AstKind,
+  savePath: string,
 ): Promise<TextDocumentIdentifier | null> => {
   const client = getClient();
   const params: ShowAstParams = {
@@ -27,6 +30,7 @@ export const showAst = async (
       uri: filePath,
     },
     astKind,
+    savePath,
   };
   return await client.sendRequest(request, params);
 };


### PR DESCRIPTION
The show lexed, parsed, and typed AST commands broke when https://github.com/FuelLabs/sway/pull/3922 landed in the server. This PR fixes this by always saving these AST into the tmp folder.