### PR TITLE
Check for forc in FUELUP_HOME

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -49,7 +49,9 @@ export function deactivate(): Thenable<void> | undefined {
 
 async function getServerOptions(): Promise<lc.ServerOptions> {
   // Look for the executable in FUELUP_HOME if it exists, otherwise use the default path.
-  const executable = process.env.FUELUP_HOME ? `${process.env.FUELUP_HOME}/bin/${LSP_EXECUTABLE_NAME}` : LSP_EXECUTABLE_NAME;
+  const executable = process.env.FUELUP_HOME
+    ? `${process.env.FUELUP_HOME}/bin/${LSP_EXECUTABLE_NAME}`
+    : LSP_EXECUTABLE_NAME;
 
   // Check if the executable exists.
   try {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -48,9 +48,13 @@ export function deactivate(): Thenable<void> | undefined {
 }
 
 async function getServerOptions(): Promise<lc.ServerOptions> {
+  // Look for the executable in FUELUP_HOME if it exists, otherwise use the default path.
+  const executable = process.env.FUELUP_HOME ? `${process.env.FUELUP_HOME}/bin/${LSP_EXECUTABLE_NAME}` : LSP_EXECUTABLE_NAME;
+
   // Check if the executable exists.
   try {
-    await promisify(exec)(`type -P ${LSP_EXECUTABLE_NAME}`);
+    let version = await promisify(exec)(`${executable} --version`);
+    log.info(`Server executable version: ${version.stdout}`);
   } catch (error) {
     window
       .showErrorMessage(
@@ -74,7 +78,7 @@ async function getServerOptions(): Promise<lc.ServerOptions> {
 
   // Get the full path to the server executable.
   const { stdout: executablePath } = await promisify(exec)(
-    `which ${LSP_EXECUTABLE_NAME}`
+    `which ${executable}`
   );
   const command = executablePath.trim();
   log.info(`Using server executable: ${command}`);

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -48,7 +48,7 @@ export function deactivate(): Thenable<void> | undefined {
 }
 
 async function getServerOptions(): Promise<lc.ServerOptions> {
-  // Look for the executable in FUELUP_HOME if it exists, otherwise use the default path.
+  // Look for the executable in FUELUP_HOME if it exists, otherwise look for it in the PATH.
   const executable = process.env.FUELUP_HOME
     ? `${process.env.FUELUP_HOME}/bin/${LSP_EXECUTABLE_NAME}`
     : LSP_EXECUTABLE_NAME;


### PR DESCRIPTION
In codespaces, the extension host may have FUELUP_HOME set without having it in the PATH. In this case, check for it in FUELUP_HOME first.