### PR TITLE
Add config for debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,10 +325,10 @@
     "breakpoints": [{ "language": "sway" }],
     "debuggers": [
       {
-        "type": "mock",
-        "label": "Mock Debug",
-        "program": "/Users/sophiedankel/.cargo/bin/fuel-debugger",
-        "args": ["--serve"],
+        "type": "sway",
+        "label": "Sway Debugger",
+        "program": "/usr/bin/env",
+        "args": ["forc-debug", "--serve"],
         "languages": ["sway"],
         "configurationAttributes": {
           "launch": {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
     "Programming Languages",
     "Extension Packs",
     "Snippets",
-    "Themes"
+    "Themes",
+    "Debuggers"
   ],
   "main": "./client/out/main",
   "activationEvents": [
+    "onDebug",
     "onLanguage:sway",
     "onView:sway",
     "onCommand:sway.runScript",
@@ -318,6 +320,42 @@
         "language": "sway",
         "scopeName": "source.sway",
         "path": "./syntaxes/sway.tmLanguage.json"
+      }
+    ],
+    "breakpoints": [{ "language": "sway" }],
+    "debuggers": [
+      {
+        "type": "mock",
+        "label": "Mock Debug",
+        "program": "/Users/sophiedankel/.cargo/bin/fuel-debugger",
+        "args": ["--serve"],
+        "languages": ["sway"],
+        "configurationAttributes": {
+          "launch": {
+            "required": [
+              "program"
+            ],
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "Absolute path to a text file.",
+                "default": "${file}"
+              }
+            }
+          },
+          "attach": {
+            "required": [
+              "program"
+            ],
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "Absolute path to a text file.",
+                "default": "${file}"
+              }
+            }
+          }
+        }
       }
     ]
   },


### PR DESCRIPTION
To use the debugger, `forc-debug` must be installed: https://github.com/FuelLabs/sway/pull/5477

Sample `launch.json` in the VSCode workspace with sway code to debug:

```
{
    "version": "0.2.0",
    "configurations": [
        {
        "type": "sway",
        "request": "launch",
        "name": "Debug Sway",
        "program": "${file}"
    }]
}
```