### PR TITLE
Add configuration to let users select their forc-lsp

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -8,7 +8,7 @@ export const getExtensionPath = () =>
   vscode.extensions.getExtension(EXTENSION_ID)!.extensionPath;
 
 export class Config {
-  private readonly requiresReloadOpts = ['debug'].map(
+  private readonly requiresReloadOpts = ['debug', 'path'].map(
     opt => `${EXTENSION_ROOT}.${opt}`
   );
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,15 +1,37 @@
 import { exec } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 import { promisify } from 'util';
 import { commands, ExtensionContext, window, workspace } from 'vscode';
 import * as lc from 'vscode-languageclient/node';
 import { createClient, getClient } from './client';
-import { Config, EXTENSION_ROOT as EXTENSION_ROOT } from './config';
+import { Config, EXTENSION_ROOT } from './config';
 import { onEnter } from './interface/onEnter';
 import { CommandPalettes } from './palettes';
 import updateFuelCoreStatus from './status_bar/fuelCoreStatus';
 import { log } from './util/util';
 
 const LSP_EXECUTABLE_NAME = 'forc-lsp';
+
+async function getSwayLspInstances(): Promise<string[]> {
+  const paths = process.env.PATH?.split(path.delimiter) || [];
+  const binaries: string[] = [];
+
+  for (const p of paths) {
+    try {
+      const files = await fs.promises.readdir(p);
+      files.forEach(file => {
+        if (file === LSP_EXECUTABLE_NAME) {
+          binaries.push(path.join(p, file));
+        }
+      });
+    } catch (err) {
+      // Ignore errors
+    }
+  }
+
+  return binaries;
+}
 
 export async function activate(context: ExtensionContext) {
   const config = new Config(context);
@@ -46,6 +68,7 @@ export async function activate(context: ExtensionContext) {
 }
 
 export function deactivate(): Thenable<void> | undefined {
+  log.info('deactivating');
   const client = getClient();
   if (!client) {
     return undefined;
@@ -53,35 +76,48 @@ export function deactivate(): Thenable<void> | undefined {
   return client.stop();
 }
 
-async function getServerOptions(): Promise<lc.ServerOptions> {
-  // Look for the executable in FUELUP_HOME if it exists, otherwise look for it in the PATH.
-  const executable = process.env.FUELUP_HOME
+function getLspPath() {
+  const defaultExecutable = process.env.FUELUP_HOME
     ? `${process.env.FUELUP_HOME}/bin/${LSP_EXECUTABLE_NAME}`
     : LSP_EXECUTABLE_NAME;
+  return workspace.getConfiguration().get('sway-lsp.path') ?? defaultExecutable;
+}
+
+async function getServerOptions(): Promise<lc.ServerOptions> {
+  // Look for the executable in FUELUP_HOME if it exists, otherwise look for it in the PATH.
+  let executable = getLspPath();
 
   // Check if the executable exists.
   try {
+    log.info('Trying with executable:', executable);
     let version = await promisify(exec)(`${executable} --version`);
     log.info(`Server executable version: ${version.stdout.trim()}`);
-  } catch (error) {
-    window
-      .showErrorMessage(
-        'The Sway Language Server is not installed. Would you like to install it?',
-        'Yes',
-        'No'
-      )
-      .then(async selection => {
-        if (selection === 'Yes') {
-          window.showInformationMessage(
-            'Follow the instructions in the terminal to install the Sway Language Server, then reload the window.'
-          );
-          commands.executeCommand('sway.installServer');
-        }
-      });
-    throw Error(`Missing executable: ${LSP_EXECUTABLE_NAME}\
-        \n\nYou may need to install the fuel toolchain or add ${process.env.HOME}/.fuelup/bin your path. Try running:\
-        \n\ncurl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh\
+  } catch (_) {
+    try {
+      executable = (await getSwayLspInstances())[0];
+      log.warn('Trying with executable from $PATH:', executable);
+      let version = await promisify(exec)(`${executable} --version`);
+      log.info(`Server executable version: ${version.stdout.trim()}`);
+    } catch (error) {
+      window
+        .showErrorMessage(
+          'The Sway Language Server is not installed. Would you like to install it?',
+          'Yes',
+          'No'
+        )
+        .then(async selection => {
+          if (selection === 'Yes') {
+            window.showInformationMessage(
+              'Follow the instructions in the terminal to install the Sway Language Server, then reload the window.'
+            );
+            commands.executeCommand('sway.installServer');
+          }
+        });
+      throw Error(`Missing executable: ${LSP_EXECUTABLE_NAME}\
+        \n\nYou may need to install the fuel toolchain or add ${process.env.HOME} /.fuelup / bin your path.Try running: \
+        \n\ncurl--proto '=https' --tlsv1.2 - sSf https://install.fuel.network/fuelup-init.sh | sh\
         \n\nOr read about fuelup for more information: https://github.com/FuelLabs/fuelup\n`);
+    }
   }
 
   // Get the full path to the server executable.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch=forever &",
     "pre:install-extension": "rm sway-vscode-plugin.vsix",
-    "install-extension": "npm run package && code --install-extension sway-vscode-plugin.vsix --force",
+    "install-extension": "npm run package && code --install-extension sway-vscode-plugin-dev.vsix --force",
     "format:check": "prettier --check 'client/src' 'snippets' 'syntaxes'",
     "format:fix": "prettier --write 'client/src' 'snippets' 'syntaxes'",
     "fix-syntaxes": "vscode-tmgrammar-snap --updateSnapshot client/test/syntaxes/*sw",
@@ -56,6 +56,11 @@
       "type": "object",
       "title": "sway-lsp",
       "properties": {
+        "sway-lsp.path": {
+          "description": "Select the path to the Sway language server.",
+          "type": "string",
+          "default": ""
+        },
         "sway-lsp.trace.server": {
           "scope": "window",
           "type": "string",


### PR DESCRIPTION
Fixes #167

By default the field is empty and it is only useful to advanced users.

The runtime will use the field to try to boot the lsp but in case the configuration is invalid it will fallback to finding the forc-lsp in $PATH