### PR TITLE
chore: Add option to disable LSP

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -91,6 +91,10 @@ export class Config {
     return this.get<string>('diagnostic.binPath');
   }
 
+  get disableLsp() {
+    return this.get<string>('diagnostic.disableLsp');
+  }
+
   get traceExtension() {
     return this.get<boolean>('trace.extension');
   }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -25,6 +25,11 @@ export async function activate(context: ExtensionContext) {
   // Start a recurring task to keep fuel-core status updated
   setInterval(updateFuelCoreStatus, 1000);
 
+  if (config.disableLsp) {
+    log.info('Sway Language Server is disabled. Exiting...');
+    return;
+  }
+
   // Listen for did_change events for on_enter capabilities.
   workspace.onDidChangeTextDocument(
     async changeEvent => await onEnter(changeEvent)

--- a/package.json
+++ b/package.json
@@ -109,7 +109,12 @@
           "default": "",
           "pattern": "(^\/(.+\/)*forc-lsp$)|^$",
           "patternErrorMessage": "Must be an absolute path to the `forc-lsp` executable, or left empty."
-        },        
+        },
+        "sway-lsp.diagnostic.disableLsp": {
+          "description": "Disable the LSP server. This will disable all language features except for basic syntax highlighting.",
+          "type": "boolean",
+          "default": false
+        },
         "sway-lsp.logging.level": {
           "scope": "window",
           "type": "string",


### PR DESCRIPTION
Some users with very large projects are having issues with LSP. This option will let them disable it while still getting syntax highlighting and debugging.

![image](https://github.com/FuelLabs/sway-vscode-plugin/assets/47993817/e280d9ac-b6ae-49be-919f-a7d2724faa12)

![image](https://github.com/FuelLabs/sway-vscode-plugin/assets/47993817/aa8d2891-ebda-4347-b15a-6bc90a7fa0bf)