### PR TITLE
fix: Only send OnEnter for sway files

### DIFF
--- a/client/src/interface/onEnter.ts
+++ b/client/src/interface/onEnter.ts
@@ -22,6 +22,7 @@ const request = new RequestType<OnEnterParams, WorkspaceEdit | null, void>(
 export const onEnter = async (changeEvent: TextDocumentChangeEvent) => {
   if (
     changeEvent.document.uri.scheme === 'file' &&
+    changeEvent.document.languageId === 'sway' &&
     changeEvent.contentChanges.length === 1 &&
     changeEvent.contentChanges[0].text.includes('\n')
   ) {


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway-vscode-plugin/issues/182

The bug was that the client was sending `on_enter` requests for non-sway files when those files were inside of a sway project.

I assumed that the plugin only received `onDidChangeTextDocument` events for changes to sway files, since we specify the language when initializing the language client. However, it appears that registering for that event gives events for all files, ignoring the document selectors in `main.ts`.