### PR TITLE
feat: Info message when LSP is out of date

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -4,8 +4,11 @@ import { log } from './util/util';
 export const EXTENSION_ID = 'fuellabs.sway-vscode-plugin';
 export const EXTENSION_ROOT = 'sway-lsp';
 
-export const getExtensionPath = () =>
-  vscode.extensions.getExtension(EXTENSION_ID)!.extensionPath;
+export const getExtension = () => vscode.extensions.getExtension(EXTENSION_ID);
+
+export const getExtensionPath = () => getExtension()!.extensionPath;
+
+export const getExtensionManifest = () => getExtension()!.packageJSON;
 
 export class Config {
   private readonly requiresReloadOpts = ['debug', 'diagnostic'].map(
@@ -14,7 +17,7 @@ export class Config {
 
   readonly package: {
     version: string;
-  } = vscode.extensions.getExtension(EXTENSION_ID)!.packageJSON;
+  } = getExtensionManifest();
 
   readonly globalStorageUri: vscode.Uri;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "child_process": "^1.0.2",
         "d3": "^7.8.5",
         "d3-graphviz": "^5.0.2",
+        "semver": "^7.6.2",
         "util": "^0.12.5",
         "vscode-languageclient": "^8.0.0-next.14"
       },
@@ -2929,6 +2930,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3588,12 +3590,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4458,7 +4457,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -6538,6 +6538,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -7014,12 +7015,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -7685,7 +7683,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Sway language extension for Visual Studio Code",
   "icon": "images/logo.png",
   "version": "0.3.5",
+  "latestForcVersion": "0.60.0",
   "publisher": "FuelLabs",
   "license": "Apache-2.0",
   "repository": {
@@ -107,7 +108,7 @@
           "description": "Optionally override the path to the Sway language server executable. If empty, the extension will use the forc-lsp executable to which your $PATH resolves (recommended for most users).",
           "type": "string",
           "default": "",
-          "pattern": "(^\/(.+\/)*forc-lsp$)|^$",
+          "pattern": "(^/(.+/)*forc-lsp$)|^$",
           "patternErrorMessage": "Must be an absolute path to the `forc-lsp` executable, or left empty."
         },
         "sway-lsp.diagnostic.disableLsp": {
@@ -391,6 +392,7 @@
     "child_process": "^1.0.2",
     "d3": "^7.8.5",
     "d3-graphviz": "^5.0.2",
+    "semver": "^7.6.2",
     "util": "^0.12.5",
     "vscode-languageclient": "^8.0.0-next.14"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Sway language extension for Visual Studio Code",
   "icon": "images/logo.png",
   "version": "0.3.5",
-  "latestForcVersion": "0.60.0",
+  "latestForcVersion": "0.63.1",
   "publisher": "FuelLabs",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Related https://github.com/FuelLabs/sway/issues/5280

Adds a custom key to the `package.json` indicating the latest version of `forc-lsp` at the time of the plugin's release. If the user's version of `forc-lsp` is older than that, they will see an info message.

![image](https://github.com/FuelLabs/sway-vscode-plugin/assets/47993817/dc3839d8-548d-422e-8758-4f2af7fb797a)