### PR TITLE
test: add RUST_BACKTRACE=FULL env var to get stack traces when crashes occur

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -151,7 +151,7 @@ async function getServerOptions(config: Config): Promise<lc.ServerOptions> {
   log.info(`Using server executable: ${command}`);
 
   const serverExecutable: lc.Executable = {
-    command,
+    command: `RUST_BACKTRACE=FULL ${command}`,
     options: {
       shell: true,
     },


### PR DESCRIPTION
This doesn't add any performance overhead and makes it easier to understand what occurred to make the server crash if and when that happens.