### PR TITLE
fix(syntax): Consistent scoping for `abi` keyword

### DIFF
--- a/syntaxes/sway.tmLanguage.json
+++ b/syntaxes/sway.tmLanguage.json
@@ -660,22 +660,22 @@
         },
         {
           "comment": "type keyword",
-          "name": "keyword.declaration.type.sway storage.type.sway",
+          "name": "keyword.declaration.type.sway",
           "match": "\\b(type)\\b"
         },
         {
           "comment": "enum keyword",
-          "name": "keyword.declaration.enum.sway storage.type.sway",
+          "name": "keyword.declaration.enum.sway",
           "match": "\\b(enum)\\b"
         },
         {
           "comment": "trait keyword",
-          "name": "keyword.declaration.trait.sway storage.type.sway",
+          "name": "keyword.declaration.trait.sway",
           "match": "\\b(trait)\\b"
         },
         {
           "comment": "abi keyword",
-          "name": "keyword.declaration.abi.sway storage.type.sway",
+          "name": "keyword.declaration.abi.sway",
           "match": "\\b(abi)\\b"
         },
         {
@@ -700,7 +700,7 @@
         },
         {
           "comment": "asm",
-          "name": "meta.attribute.asm.sway",
+          "name": "keyword.other.asm.sway",
           "match": "\\basm\\b"
         },
         {
@@ -968,7 +968,7 @@
           "match": "\\b(trait)\\s+([A-Z][A-Za-z0-9]*)\\b",
           "captures": {
             "1": {
-              "name": "keyword.declaration.trait.sway storage.type.sway"
+              "name": "keyword.declaration.trait.sway"
             },
             "2": {
               "name": "entity.name.type.trait.sway"
@@ -980,7 +980,7 @@
           "match": "\\b(abi)\\s+([A-Z][A-Za-z0-9]*)\\b",
           "captures": {
             "1": {
-              "name": "keyword.declaration.abi.sway storage.type.sway"
+              "name": "keyword.declaration.abi.sway"
             },
             "2": {
               "name": "entity.name.type.abi.sway"
@@ -1016,7 +1016,7 @@
           "match": "\\b(type)\\s+([A-Z][A-Za-z0-9_]*)\\b",
           "captures": {
             "1": {
-              "name": "keyword.declaration.type.sway storage.type.sway"
+              "name": "keyword.declaration.type.sway"
             },
             "2": {
               "name": "entity.name.type.declaration.sway"


### PR DESCRIPTION
Fixes inconsistent highlighting for the `abi` keyword. As observed (see screenshot), the keyword was sometimes scoped differently depending on whether it was followed by a name.

This PR removes the redundant `storage.type.sway` scope from the `abi` keyword rules, ensuring it's consistently scoped as `keyword.declaration.abi.sway`. Similar consistency cleanups were applied to `enum`, `trait`, and `type` keywords.

<img width="642" alt="Screenshot 2025-05-05 at 2 39 52 pm" src="https://github.com/user-attachments/assets/3edd8e8c-0ccf-4e42-bf53-a3d0d394c39d" />
