### PR TITLE
fix: add GitHub token permissions to validate-pr-title CI job

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,8 +7,11 @@ on:
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: PR Conventional Commit Validation
         uses:  ytanikin/PRConventionalCommits@1.1.0
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes "Resource not accessible by integration" error that is occurring [here ](https://github.com/FuelLabs/sway-vscode-plugin/actions/runs/16104631436?pr=194) by adding required GITHUB_TOKEN and pull-requests read permissions to the conventional commits validation workflow.