### PR TITLE
fix: disable PR labeling in conventional commits validation

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -15,3 +15,4 @@ jobs:
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
           token: ${{ secrets.GITHUB_TOKEN }}
+          add_label: 'false'


### PR DESCRIPTION
Disables automatic PR labeling to avoid requiring write permissions and fix "Resource not accessible by integration" error.